### PR TITLE
Introduce Metadata field and provide process_guid to kube deployments.

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -8,6 +8,7 @@ import (
 
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/eirini"
+	"code.cloudfoundry.org/eirini/models/cf"
 	"code.cloudfoundry.org/eirini/opi"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/runtimeschema/cc_messages"
@@ -67,7 +68,7 @@ func toDesiredLRPSchedulingInfo(lrps []opi.LRP) []*models.DesiredLRPSchedulingIn
 	infos := []*models.DesiredLRPSchedulingInfo{}
 	for _, l := range lrps {
 		info := &models.DesiredLRPSchedulingInfo{}
-		info.DesiredLRPKey.ProcessGuid = l.Name
+		info.DesiredLRPKey.ProcessGuid = l.Metadata[cf.ProcessGuid]
 		infos = append(infos, info)
 	}
 	return infos

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -82,9 +82,9 @@ var _ = Describe("Bifrost", func() {
 
 			BeforeEach(func() {
 				lrps = []opi.LRP{
-					opi.LRP{Name: "1234"},
-					opi.LRP{Name: "5678"},
-					opi.LRP{Name: "0213"},
+					opi.LRP{Name: "1234", Metadata: map[string]string{"process_guid": "abcd"}},
+					opi.LRP{Name: "5678", Metadata: map[string]string{"process_guid": "efgh"}},
+					opi.LRP{Name: "0213", Metadata: map[string]string{"process_guid": "ijkl"}},
 				}
 			})
 
@@ -92,9 +92,9 @@ var _ = Describe("Bifrost", func() {
 				desiredLRPSchedulingInfos, err := bfrst.List(context.Background())
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(desiredLRPSchedulingInfos[0].ProcessGuid).To(Equal("1234"))
-				Expect(desiredLRPSchedulingInfos[1].ProcessGuid).To(Equal("5678"))
-				Expect(desiredLRPSchedulingInfos[2].ProcessGuid).To(Equal("0213"))
+				Expect(desiredLRPSchedulingInfos[0].ProcessGuid).To(Equal("abcd"))
+				Expect(desiredLRPSchedulingInfos[1].ProcessGuid).To(Equal("efgh"))
+				Expect(desiredLRPSchedulingInfos[2].ProcessGuid).To(Equal("ijkl"))
 			})
 		})
 

--- a/bifrost/convert.go
+++ b/bifrost/convert.go
@@ -9,6 +9,7 @@ import (
 
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/eirini"
+	"code.cloudfoundry.org/eirini/models/cf"
 	"code.cloudfoundry.org/eirini/opi"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/runtimeschema/cc_messages"
@@ -22,19 +23,44 @@ func Convert(
 	client *http.Client,
 	log lager.Logger,
 ) opi.LRP {
+	envMap := envVarsToMap(msg.Environment)
+	vcap := parseVcapApplication(envMap["VCAP_APPLICATION"])
+
 	if msg.DockerImageUrl == "" {
-		msg.DockerImageUrl = dropletToImageURI(msg, cfClient, client, registryUrl, registryIP, log)
+		msg.DockerImageUrl = dropletToImageURI(msg, vcap, cfClient, client, registryUrl, registryIP, log)
+	}
+
+	uris, err := json.Marshal(vcap.AppUris)
+	if err != nil {
+		log.Error("failed-to-marshal-vcap-app-uris", err, lager.Data{"app-guid": vcap.AppId})
+		uris = []byte{}
 	}
 
 	return opi.LRP{
-		Name:            msg.ProcessGuid,
+		Name:            vcap.AppId,
 		Image:           msg.DockerImageUrl,
 		TargetInstances: msg.NumInstances,
 		Command: []string{
 			msg.StartCommand,
 		},
-		Env: envVarsToMap(msg.Environment),
+		Env: envMap,
+		Metadata: map[string]string{
+			cf.VcapAppName: vcap.AppName,
+			cf.VcapAppId:   vcap.AppId,
+			cf.VcapVersion: vcap.Version,
+			cf.VcapAppUris: string(uris),
+			cf.ProcessGuid: msg.ProcessGuid,
+		},
 	}
+}
+
+func parseVcapApplication(vcap string) cf.VcapApp {
+	var vcapApp cf.VcapApp
+	if err := json.Unmarshal([]byte(vcap), &vcapApp); err != nil {
+		panic(err)
+	}
+
+	return vcapApp
 }
 
 func envVarsToMap(envs []*models.EnvironmentVariable) map[string]string {
@@ -47,30 +73,20 @@ func envVarsToMap(envs []*models.EnvironmentVariable) map[string]string {
 
 func dropletToImageURI(
 	msg cc_messages.DesireAppRequestFromCC,
+	vcap cf.VcapApp,
 	cfClient eirini.CfClient,
 	client *http.Client,
 	registryUrl string,
 	registryIP string,
 	log lager.Logger,
 ) string {
-	var appInfo eirini.AppInfo
-	for _, v := range msg.Environment {
-		if v.Name == "VCAP_APPLICATION" {
-			err := json.Unmarshal([]byte(v.Value), &appInfo)
-			if err != nil {
-				log.Error("failed-to-decode-environment-json-from-cc_message", err)
-				panic(err)
-			}
-		}
-	}
-
-	dropletBytes, err := cfClient.GetDropletByAppGuid(appInfo.AppGuid)
+	dropletBytes, err := cfClient.GetDropletByAppGuid(vcap.AppId)
 	if err != nil {
-		log.Error("failed-to-get-droplet-from-cloud-controller", err, lager.Data{"app-guid": appInfo.AppGuid})
+		log.Error("failed-to-get-droplet-from-cloud-controller", err, lager.Data{"app-guid": vcap.AppId})
 		panic(err)
 	}
 
-	stageRequest(client, registryUrl, appInfo, msg.DropletHash, dropletBytes, log)
+	stageRequest(client, registryUrl, vcap, msg.DropletHash, dropletBytes, log)
 
 	return fmt.Sprintf("%s/cloudfoundry/app-name:%s", registryIP, msg.DropletHash)
 }
@@ -78,12 +94,12 @@ func dropletToImageURI(
 func stageRequest(
 	client *http.Client,
 	registryUrl string,
-	appInfo eirini.AppInfo,
+	vcap cf.VcapApp,
 	dropletHash string,
 	dropletBytes []byte,
 	log lager.Logger,
 ) string {
-	registryStageUri := registryStageUri(registryUrl, appInfo.SpaceName, appInfo.AppName, dropletHash)
+	registryStageUri := registryStageUri(registryUrl, vcap.SpaceName, vcap.AppName, dropletHash)
 
 	log.Info("sending-request-to-registry", lager.Data{"request": registryStageUri})
 
@@ -111,12 +127,4 @@ func stageRequest(
 
 	return string(digest)
 
-}
-
-func dropletDownloadUri(baseUrl string, appGuid string) string {
-	return fmt.Sprintf("%s/v2/apps/%s/droplet/download", baseUrl, appGuid)
-}
-
-func registryStageUri(baseUrl string, space string, appname string, guid string) string {
-	return fmt.Sprintf("%s/v2/%s/%s/blobs/?guid=%s", baseUrl, space, appname, guid)
 }

--- a/bifrost/convert_test.go
+++ b/bifrost/convert_test.go
@@ -16,53 +16,72 @@ import (
 
 var _ = Describe("Convert CC DesiredApp into an opi LRP", func() {
 	var (
-		cfClient   *eirinifakes.FakeCfClient
-		fakeServer *ghttp.Server
-		logger     *lagertest.TestLogger
-		client     *http.Client
-		lrp        opi.LRP
-		regIP      string
+		cfClient         *eirinifakes.FakeCfClient
+		fakeServer       *ghttp.Server
+		logger           *lagertest.TestLogger
+		client           *http.Client
+		lrp              opi.LRP
+		desireAppRequest cc_messages.DesireAppRequestFromCC
 	)
 
 	BeforeEach(func() {
+		desireAppRequest = cc_messages.DesireAppRequestFromCC{
+			ProcessGuid:    "b194809b-88c0-49af-b8aa-69da097fc360-2fdc448f-6bac-4085-9426-87d0124c433a",
+			DropletHash:    "the-droplet-hash",
+			DockerImageUrl: "the-image-url",
+			NumInstances:   3,
+			Environment: []*models.EnvironmentVariable{
+				&models.EnvironmentVariable{
+					Name:  "VCAP_APPLICATION",
+					Value: `{"application_name":"bumblebee", "space_name":"transformers", "application_id":"b194809b-88c0-49af-b8aa-69da097fc360", "version": "something-something-uuid", "application_uris":["bumblebee.example.com", "transformers.example.com"]}`,
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
 		cfClient = new(eirinifakes.FakeCfClient)
 		fakeServer = ghttp.NewServer()
 		logger = lagertest.NewTestLogger("test")
 		client = &http.Client{}
-		regIP = "eirini-registry.service.cf.internal"
 		fakeServer.AppendHandlers(
 			ghttp.VerifyRequest("POST", "/v2/transformers/bumblebee/blobs/"),
 		)
+
+		regIP := "eirini-registry.service.cf.internal"
+		lrp = bifrost.Convert(desireAppRequest, fakeServer.URL(), regIP, cfClient, client, logger)
 	})
 
-	AfterEach(func() {
+	AfterSuite(func() {
 		fakeServer.Close()
 	})
 
 	It("Directly converts DockerImageURL, Instances fields", func() {
-		lrp := bifrost.Convert(cc_messages.DesireAppRequestFromCC{
-			DockerImageUrl: "the-image-url",
-			NumInstances:   3,
-		}, fakeServer.URL(), regIP, cfClient, client, logger)
-
 		Expect(lrp.Image).To(Equal("the-image-url"))
 		Expect(lrp.TargetInstances).To(Equal(3))
 	})
 
-	BeforeEach(func() {
-		lrp = bifrost.Convert(cc_messages.DesireAppRequestFromCC{
-			ProcessGuid: "b194809b-88c0-49af-b8aa-69da097fc360-2fdc448f-6bac-4085-9426-87d0124c433a",
-			DropletHash: "the-droplet-hash",
-			Environment: []*models.EnvironmentVariable{
-				&models.EnvironmentVariable{
-					Name:  "VCAP_APPLICATION",
-					Value: `{"name":"bumblebee", "space_name":"transformers", "application_id":"1234"}`,
-				},
-			},
-		}, fakeServer.URL(), regIP, cfClient, client, logger)
+	It("should set the lrp.Name equal to the app id", func() {
+		Expect(lrp.Name).To(Equal("b194809b-88c0-49af-b8aa-69da097fc360"))
 	})
 
-	It("Converts droplet apps via the special registry URL", func() {
-		Expect(lrp.Image).To(Equal("eirini-registry.service.cf.internal/cloudfoundry/app-name:the-droplet-hash"))
+	It("stores the VCAP env variable as metadata", func() {
+		Expect(lrp.Metadata["application_name"]).To(Equal("bumblebee"))
+		Expect(lrp.Metadata["application_id"]).To(Equal("b194809b-88c0-49af-b8aa-69da097fc360"))
+		Expect(lrp.Metadata["version"]).To(Equal("something-something-uuid"))
+	})
+
+	It("stores the process guid in metadata", func() {
+		Expect(lrp.Metadata["process_guid"]).To(Equal("b194809b-88c0-49af-b8aa-69da097fc360-2fdc448f-6bac-4085-9426-87d0124c433a"))
+	})
+
+	Context("When the Docker Image Url is not provided", func() {
+		BeforeEach(func() {
+			desireAppRequest.DockerImageUrl = ""
+		})
+
+		It("Converts droplet apps via the special registry URL", func() {
+			Expect(lrp.Image).To(Equal("eirini-registry.service.cf.internal/cloudfoundry/app-name:the-droplet-hash"))
+		})
 	})
 })

--- a/bifrost/models.go
+++ b/bifrost/models.go
@@ -1,6 +1,7 @@
 package bifrost
 
 import (
+	"fmt"
 	"net/http"
 
 	"code.cloudfoundry.org/eirini"
@@ -17,4 +18,12 @@ type ConvertFunc func(cc cc_messages.DesireAppRequestFromCC, registryUrl string,
 
 func (fn ConvertFunc) Convert(cc cc_messages.DesireAppRequestFromCC, registryUrl string, registryIP string, cfClient eirini.CfClient, client *http.Client, log lager.Logger) opi.LRP {
 	return fn(cc, registryUrl, registryIP, cfClient, client, log)
+}
+
+func dropletDownloadUri(baseUrl string, appGuid string) string {
+	return fmt.Sprintf("%s/v2/apps/%s/droplet/download", baseUrl, appGuid)
+}
+
+func registryStageUri(baseUrl string, space string, appname string, guid string) string {
+	return fmt.Sprintf("%s/v2/%s/%s/blobs/?guid=%s", baseUrl, space, appname, guid)
 }

--- a/k8s/deployment.go
+++ b/k8s/deployment.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"code.cloudfoundry.org/eirini/models/cf"
 	"code.cloudfoundry.org/eirini/opi"
 	"k8s.io/api/apps/v1beta1"
 	av1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,11 @@ func (m *deploymentManager) ListLRPs(namespace string) ([]opi.LRP, error) {
 func toLRPs(deployments *v1beta1.DeploymentList) []opi.LRP {
 	lrps := []opi.LRP{}
 	for _, d := range deployments.Items {
-		lrp := opi.LRP{Name: d.Name}
+		lrp := opi.LRP{
+			Metadata: map[string]string{
+				cf.ProcessGuid: d.Annotations[cf.ProcessGuid],
+			},
+		}
 		lrps = append(lrps, lrp)
 	}
 	return lrps

--- a/k8s/ingress_test.go
+++ b/k8s/ingress_test.go
@@ -86,12 +86,12 @@ var _ = Describe("Ingress", func() {
 		const (
 			ingressAppName = "app-name"
 			lrpName        = "new-app-name"
-			vcapName       = "new-vcaapp-name"
+			appName        = "new-vcaapp-name"
 		)
 
 		createIngressRule := func(serviceName string) ext.IngressRule {
 			ingress := ext.IngressRule{
-				Host: fmt.Sprintf("%s.%s", vcapName, kubeEndpoint),
+				Host: fmt.Sprintf("%s.%s", appName, kubeEndpoint),
 			}
 
 			ingress.HTTP = &ext.HTTPIngressRuleValue{
@@ -130,10 +130,13 @@ var _ = Describe("Ingress", func() {
 		}
 
 		JustBeforeEach(func() {
-			lrp := opi.LRP{Name: lrpName}
-			vcap := VcapApp{AppName: vcapName}
+			lrp := opi.LRP{
+				Name: lrpName,
+				Metadata: map[string]string{
+					"application_name": appName,
+				}}
 
-			err = ingressManager.UpdateIngress(namespace, lrp, vcap)
+			err = ingressManager.UpdateIngress(namespace, lrp)
 		})
 
 		Context("When ingress already exists", func() {
@@ -152,7 +155,7 @@ var _ = Describe("Ingress", func() {
 				ingress, err := fakeClient.ExtensionsV1beta1().Ingresses(namespace).Get(ingressName, av1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				tlsHosts := []string{fmt.Sprintf("%s.%s", ingressAppName, kubeEndpoint), fmt.Sprintf("%s.%s", vcapName, kubeEndpoint)}
+				tlsHosts := []string{fmt.Sprintf("%s.%s", ingressAppName, kubeEndpoint), fmt.Sprintf("%s.%s", appName, kubeEndpoint)}
 				Expect(ingress.Spec.TLS).To(Equal([]ext.IngressTLS{
 					ext.IngressTLS{
 						Hosts: tlsHosts,
@@ -177,7 +180,7 @@ var _ = Describe("Ingress", func() {
 				ingress, err := fakeClient.ExtensionsV1beta1().Ingresses(namespace).Get(ingressName, av1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				tlsHosts := []string{fmt.Sprintf("%s.%s", vcapName, kubeEndpoint)}
+				tlsHosts := []string{fmt.Sprintf("%s.%s", appName, kubeEndpoint)}
 				Expect(ingress.Spec.TLS).To(Equal([]ext.IngressTLS{
 					ext.IngressTLS{
 						Hosts: tlsHosts,

--- a/k8s/k8sfakes/fake_ingress_manager.go
+++ b/k8s/k8sfakes/fake_ingress_manager.go
@@ -23,12 +23,11 @@ type FakeIngressManager struct {
 		result1 *ext.Ingress
 		result2 error
 	}
-	UpdateIngressStub        func(namespace string, lrp opi.LRP, vcap k8s.VcapApp) error
+	UpdateIngressStub        func(namespace string, lrp opi.LRP) error
 	updateIngressMutex       sync.RWMutex
 	updateIngressArgsForCall []struct {
 		namespace string
 		lrp       opi.LRP
-		vcap      k8s.VcapApp
 	}
 	updateIngressReturns struct {
 		result1 error
@@ -91,18 +90,17 @@ func (fake *FakeIngressManager) CreateIngressReturnsOnCall(i int, result1 *ext.I
 	}{result1, result2}
 }
 
-func (fake *FakeIngressManager) UpdateIngress(namespace string, lrp opi.LRP, vcap k8s.VcapApp) error {
+func (fake *FakeIngressManager) UpdateIngress(namespace string, lrp opi.LRP) error {
 	fake.updateIngressMutex.Lock()
 	ret, specificReturn := fake.updateIngressReturnsOnCall[len(fake.updateIngressArgsForCall)]
 	fake.updateIngressArgsForCall = append(fake.updateIngressArgsForCall, struct {
 		namespace string
 		lrp       opi.LRP
-		vcap      k8s.VcapApp
-	}{namespace, lrp, vcap})
-	fake.recordInvocation("UpdateIngress", []interface{}{namespace, lrp, vcap})
+	}{namespace, lrp})
+	fake.recordInvocation("UpdateIngress", []interface{}{namespace, lrp})
 	fake.updateIngressMutex.Unlock()
 	if fake.UpdateIngressStub != nil {
-		return fake.UpdateIngressStub(namespace, lrp, vcap)
+		return fake.UpdateIngressStub(namespace, lrp)
 	}
 	if specificReturn {
 		return ret.result1
@@ -116,10 +114,10 @@ func (fake *FakeIngressManager) UpdateIngressCallCount() int {
 	return len(fake.updateIngressArgsForCall)
 }
 
-func (fake *FakeIngressManager) UpdateIngressArgsForCall(i int) (string, opi.LRP, k8s.VcapApp) {
+func (fake *FakeIngressManager) UpdateIngressArgsForCall(i int) (string, opi.LRP) {
 	fake.updateIngressMutex.RLock()
 	defer fake.updateIngressMutex.RUnlock()
-	return fake.updateIngressArgsForCall[i].namespace, fake.updateIngressArgsForCall[i].lrp, fake.updateIngressArgsForCall[i].vcap
+	return fake.updateIngressArgsForCall[i].namespace, fake.updateIngressArgsForCall[i].lrp
 }
 
 func (fake *FakeIngressManager) UpdateIngressReturns(result1 error) {

--- a/models.go
+++ b/models.go
@@ -23,12 +23,6 @@ const (
 	EnvEiriniAddress      = "EIRINI_ADDRESS"
 )
 
-type AppInfo struct {
-	AppName   string `json:"name"`
-	SpaceName string `json:"space_name"`
-	AppGuid   string `json:"application_id"`
-}
-
 //go:generate counterfeiter . CfClient
 type CfClient interface {
 	GetDropletByAppGuid(string) ([]byte, error)

--- a/models/cf/models.go
+++ b/models/cf/models.go
@@ -1,0 +1,19 @@
+package cf
+
+const (
+	VcapAppName   = "application_name"
+	VcapVersion   = "version"
+	VcapAppUris   = "application_uris"
+	VcapAppId     = "application_id"
+	VcapSpaceName = "space_name"
+
+	ProcessGuid = "process_guid"
+)
+
+type VcapApp struct {
+	AppName   string   `json:"application_name"`
+	AppId     string   `json:"application_id"`
+	Version   string   `json:"version"`
+	AppUris   []string `json:"application_uris"`
+	SpaceName string   `json:"space_name"`
+}

--- a/opi/model.go
+++ b/opi/model.go
@@ -13,6 +13,7 @@ type LRP struct {
 	Command         []string
 	Env             map[string]string
 	TargetInstances int
+	Metadata        map[string]string
 }
 
 // A Task is a one-off process that is run exactly once and returns a


### PR DESCRIPTION
In order to have easier access to required VCAP_APPLICATION data, this
commit introduces Metadata which saves all necessary information in a
map. This includes - beside the vcap info - the process_guid which is
comming from desiredLRPRequestFromCC.

Signed-off-by: Julian Skupnjak <skupnjak@de.ibm.com>
Signed-off-by: Georgi Dankov <gddankov@gmail.com>
Signed-off-by: Steffen Uhlig <Steffen.Uhlig@de.ibm.com>