### PR TITLE
Delete the associated Headless Service when deleting a StatefulSet

### DIFF
--- a/k8s/k8sfakes/fake_service_manager.go
+++ b/k8s/k8sfakes/fake_service_manager.go
@@ -42,6 +42,17 @@ type FakeServiceManager struct {
 	deleteReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteHeadlessStub        func(appName string) error
+	deleteHeadlessMutex       sync.RWMutex
+	deleteHeadlessArgsForCall []struct {
+		appName string
+	}
+	deleteHeadlessReturns struct {
+		result1 error
+	}
+	deleteHeadlessReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -190,6 +201,54 @@ func (fake *FakeServiceManager) DeleteReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeServiceManager) DeleteHeadless(appName string) error {
+	fake.deleteHeadlessMutex.Lock()
+	ret, specificReturn := fake.deleteHeadlessReturnsOnCall[len(fake.deleteHeadlessArgsForCall)]
+	fake.deleteHeadlessArgsForCall = append(fake.deleteHeadlessArgsForCall, struct {
+		appName string
+	}{appName})
+	fake.recordInvocation("DeleteHeadless", []interface{}{appName})
+	fake.deleteHeadlessMutex.Unlock()
+	if fake.DeleteHeadlessStub != nil {
+		return fake.DeleteHeadlessStub(appName)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.deleteHeadlessReturns.result1
+}
+
+func (fake *FakeServiceManager) DeleteHeadlessCallCount() int {
+	fake.deleteHeadlessMutex.RLock()
+	defer fake.deleteHeadlessMutex.RUnlock()
+	return len(fake.deleteHeadlessArgsForCall)
+}
+
+func (fake *FakeServiceManager) DeleteHeadlessArgsForCall(i int) string {
+	fake.deleteHeadlessMutex.RLock()
+	defer fake.deleteHeadlessMutex.RUnlock()
+	return fake.deleteHeadlessArgsForCall[i].appName
+}
+
+func (fake *FakeServiceManager) DeleteHeadlessReturns(result1 error) {
+	fake.DeleteHeadlessStub = nil
+	fake.deleteHeadlessReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeServiceManager) DeleteHeadlessReturnsOnCall(i int, result1 error) {
+	fake.DeleteHeadlessStub = nil
+	if fake.deleteHeadlessReturnsOnCall == nil {
+		fake.deleteHeadlessReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteHeadlessReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeServiceManager) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -199,6 +258,8 @@ func (fake *FakeServiceManager) Invocations() map[string][][]interface{} {
 	defer fake.createHeadlessMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
+	fake.deleteHeadlessMutex.RLock()
+	defer fake.deleteHeadlessMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/k8s/service.go
+++ b/k8s/service.go
@@ -15,6 +15,7 @@ type ServiceManager interface {
 	Create(lrp *opi.LRP) error
 	CreateHeadless(lrp *opi.LRP) error
 	Delete(appName string) error
+	DeleteHeadless(appName string) error
 }
 
 type serviceManager struct {
@@ -33,11 +34,6 @@ func (m *serviceManager) services() types.ServiceInterface {
 	return m.client.CoreV1().Services(m.namespace)
 }
 
-func (m *serviceManager) Delete(appName string) error {
-	serviceName := eirini.GetInternalServiceName(appName)
-	return m.services().Delete(serviceName, &meta_v1.DeleteOptions{})
-}
-
 func (m *serviceManager) Create(lrp *opi.LRP) error {
 	_, err := m.services().Create(toService(lrp))
 	return err
@@ -46,6 +42,16 @@ func (m *serviceManager) Create(lrp *opi.LRP) error {
 func (m *serviceManager) CreateHeadless(lrp *opi.LRP) error {
 	_, err := m.services().Create(toHeadlessService(lrp))
 	return err
+}
+
+func (m *serviceManager) Delete(appName string) error {
+	serviceName := eirini.GetInternalServiceName(appName)
+	return m.services().Delete(serviceName, &meta_v1.DeleteOptions{})
+}
+
+func (m *serviceManager) DeleteHeadless(appName string) error {
+	serviceName := eirini.GetInternalHeadlessServiceName(appName)
+	return m.services().Delete(serviceName, &meta_v1.DeleteOptions{})
 }
 
 func toService(lrp *opi.LRP) *v1.Service {

--- a/k8s/statefulset.go
+++ b/k8s/statefulset.go
@@ -39,7 +39,10 @@ func (m *StatefulSetManager) List() ([]*opi.LRP, error) {
 
 func (m *StatefulSetManager) Delete(appName string) error {
 	backgroundPropagation := meta.DeletePropagationBackground
-	return m.statefulSets().Delete(appName, &meta.DeleteOptions{PropagationPolicy: &backgroundPropagation})
+	if err := m.statefulSets().Delete(appName, &meta.DeleteOptions{PropagationPolicy: &backgroundPropagation}); err != nil {
+		return err
+	}
+	return m.ServiceManager.DeleteHeadless(appName)
 }
 
 func (m *StatefulSetManager) Create(lrp *opi.LRP) error {


### PR DESCRIPTION
* Add a `DeleteHeadless` method in `ServiceManager`
* Use it when deleting a `StatefulSet`

[#159335321]