### PR TITLE
Experimental Support for CF Volume Services

### DIFF
--- a/bifrost/convert.go
+++ b/bifrost/convert.go
@@ -54,6 +54,14 @@ func (c *DropletToImageConverter) Convert(request cf.DesireLRPRequest) (opi.LRP,
 
 	lev := launcher.SetupEnv(request.StartCommand)
 
+	var volumeMounts []opi.VolumeMount
+	for _, vm := range request.VolumeMounts {
+		volumeMounts = append(volumeMounts, opi.VolumeMount{
+			MountPath: vm.ContainerDir,
+			ClaimName: vm.Shared.MountConfig.Name,
+		})
+	}
+
 	return opi.LRP{
 		Name:            vcap.AppID,
 		Image:           request.DockerImageURL,
@@ -74,6 +82,7 @@ func (c *DropletToImageConverter) Convert(request cf.DesireLRPRequest) (opi.LRP,
 			cf.ProcessGUID: request.ProcessGUID,
 			cf.LastUpdated: request.LastUpdated,
 		},
+		VolumeMounts: volumeMounts,
 	}, nil
 }
 

--- a/bifrost/convert.go
+++ b/bifrost/convert.go
@@ -58,7 +58,7 @@ func (c *DropletToImageConverter) Convert(request cf.DesireLRPRequest) (opi.LRP,
 	for _, vm := range request.VolumeMounts {
 		volumeMounts = append(volumeMounts, opi.VolumeMount{
 			MountPath: vm.MountDir,
-			ClaimName: vm.VolumeId,
+			ClaimName: vm.VolumeID,
 		})
 	}
 

--- a/bifrost/convert.go
+++ b/bifrost/convert.go
@@ -54,7 +54,7 @@ func (c *DropletToImageConverter) Convert(request cf.DesireLRPRequest) (opi.LRP,
 
 	lev := launcher.SetupEnv(request.StartCommand)
 
-	var volumeMounts []opi.VolumeMount
+	volumeMounts := []opi.VolumeMount{}
 	for _, vm := range request.VolumeMounts {
 		volumeMounts = append(volumeMounts, opi.VolumeMount{
 			MountPath: vm.ContainerDir,

--- a/bifrost/convert.go
+++ b/bifrost/convert.go
@@ -57,8 +57,8 @@ func (c *DropletToImageConverter) Convert(request cf.DesireLRPRequest) (opi.LRP,
 	volumeMounts := []opi.VolumeMount{}
 	for _, vm := range request.VolumeMounts {
 		volumeMounts = append(volumeMounts, opi.VolumeMount{
-			MountPath: vm.ContainerDir,
-			ClaimName: vm.Shared.MountConfig.Name,
+			MountPath: vm.MountDir,
+			ClaimName: vm.VolumeId,
 		})
 	}
 

--- a/bifrost/convert_test.go
+++ b/bifrost/convert_test.go
@@ -53,6 +53,16 @@ var _ = Describe("Convert CC DesiredApp into an opi LRP", func() {
 			HealthCheckType:         "http",
 			HealthCheckHTTPEndpoint: "/heat",
 			HealthCheckTimeoutMs:    400,
+			VolumeMounts: []cf.VolumeMount{
+				{
+					VolumeId: "claim-one",
+					MountDir: "/path/one",
+				},
+				{
+					VolumeId: "claim-two",
+					MountDir: "/path/two",
+				},
+			},
 		}
 	})
 
@@ -126,7 +136,18 @@ var _ = Describe("Convert CC DesiredApp into an opi LRP", func() {
 				Expect(health.Endpoint).To(Equal("/heat"))
 				Expect(health.TimeoutMs).To(Equal(uint(400)))
 			})
-
+			It("should set the volume mounts", func() {
+				volumes := lrp.VolumeMounts
+				Expect(len(volumes)).To(Equal(2))
+				Expect(volumes).To(ContainElement(opi.VolumeMount{
+					ClaimName: "claim-one",
+					MountPath: "/path/one",
+				}))
+				Expect(volumes).To(ContainElement(opi.VolumeMount{
+					ClaimName: "claim-two",
+					MountPath: "/path/two",
+				}))
+			})
 		}
 
 		Context("When the Docker image is provided", func() {

--- a/bifrost/convert_test.go
+++ b/bifrost/convert_test.go
@@ -55,11 +55,11 @@ var _ = Describe("Convert CC DesiredApp into an opi LRP", func() {
 			HealthCheckTimeoutMs:    400,
 			VolumeMounts: []cf.VolumeMount{
 				{
-					VolumeId: "claim-one",
+					VolumeID: "claim-one",
 					MountDir: "/path/one",
 				},
 				{
-					VolumeId: "claim-two",
+					VolumeID: "claim-two",
 					MountDir: "/path/two",
 				},
 			},

--- a/handler/app_handler.go
+++ b/handler/app_handler.go
@@ -1,8 +1,10 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/bbs/models"
@@ -23,8 +25,16 @@ type App struct {
 }
 
 func (a *App) Desire(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		a.logger.Error("reading-request-body", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	a.logger.Debug("desire-request", lager.Data{"body": string(body)})
+
 	var request cf.DesireLRPRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&request); err != nil {
 		a.logger.Error("request-body-decoding-failed", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -97,8 +107,16 @@ func (a *App) GetApp(w http.ResponseWriter, r *http.Request, ps httprouter.Param
 }
 
 func (a *App) Update(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		a.logger.Error("reading-request-body", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	a.logger.Debug("update-request", lager.Data{"body": string(body)})
+
 	var request models.UpdateDesiredLRPRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&request); err != nil {
 		a.logger.Error("json-decoding-failure", err)
 		err = writeUpdateErrorResponse(w, err, http.StatusBadRequest)
 

--- a/handler/app_handler.go
+++ b/handler/app_handler.go
@@ -1,10 +1,8 @@
 package handler
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/bbs/models"
@@ -25,16 +23,8 @@ type App struct {
 }
 
 func (a *App) Desire(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		a.logger.Error("reading-request-body", err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	a.logger.Debug("desire-request", lager.Data{"body": string(body)})
-
 	var request cf.DesireLRPRequest
-	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		a.logger.Error("request-body-decoding-failed", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -107,16 +97,8 @@ func (a *App) GetApp(w http.ResponseWriter, r *http.Request, ps httprouter.Param
 }
 
 func (a *App) Update(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		a.logger.Error("reading-request-body", err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	a.logger.Debug("update-request", lager.Data{"body": string(body)})
-
 	var request models.UpdateDesiredLRPRequest
-	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		a.logger.Error("json-decoding-failure", err)
 		err = writeUpdateErrorResponse(w, err, http.StatusBadRequest)
 

--- a/handler/app_handler_test.go
+++ b/handler/app_handler_test.go
@@ -53,14 +53,9 @@ var _ = Describe("AppHandler", func() {
 				"health_check_timeout_ms":400,
 				"volume_mounts": [
 				  {
-						"driver": "csi",
-						"container_dir": "/var/vcap/data/e1df89b4-33de-4d72-b471-5495222177c8",
-						"mode": "rw",
-						"shared": {
-							"volume_id": "e1df89b4-33de-4d72-b471-5495222177c8-volume",
-							"mount_config": "{\"name\":\"vol1\"}"
-						}
-					}
+						"mount_dir": "/var/vcap/data/e1df89b4-33de-4d72-b471-5495222177c8",
+						"volume_id":"vol1"
+			       	  }
 				]
 			}`
 		})
@@ -87,12 +82,8 @@ var _ = Describe("AppHandler", func() {
 				HealthCheckTimeoutMs:    400,
 				VolumeMounts: []cf.VolumeMount{
 					{
-						ContainerDir: "/var/vcap/data/e1df89b4-33de-4d72-b471-5495222177c8",
-						Shared: cf.SharedVolumeConfig{
-							MountConfig: cf.VolumeMountConfig{
-								Name: "vol1",
-							},
-						},
+						MountDir: "/var/vcap/data/e1df89b4-33de-4d72-b471-5495222177c8",
+						VolumeId: "vol1",
 					},
 				},
 			}

--- a/handler/app_handler_test.go
+++ b/handler/app_handler_test.go
@@ -42,7 +42,27 @@ var _ = Describe("AppHandler", func() {
 
 		BeforeEach(func() {
 			path = "/apps/myguid"
-			body = `{"process_guid" : "myguid", "start_command": "./start", "environment": { "env_var": "env_var_value" }, "instances": 5, "last_updated":"1529073295.9","health_check_type":"http","health_check_http_endpoint":"/healthz","health_check_timeout_ms":400}`
+			body = `{
+				"process_guid" : "myguid",
+				"start_command": "./start",
+				"environment": { "env_var": "env_var_value" },
+				"instances": 5,
+				"last_updated":"1529073295.9",
+				"health_check_type":"http",
+				"health_check_http_endpoint":"/healthz",
+				"health_check_timeout_ms":400,
+				"volume_mounts": [
+				  {
+						"driver": "csi",
+						"container_dir": "/var/vcap/data/e1df89b4-33de-4d72-b471-5495222177c8",
+						"mode": "rw",
+						"shared": {
+							"volume_id": "e1df89b4-33de-4d72-b471-5495222177c8-volume",
+							"mount_config": "{\"name\":\"vol1\"}"
+						}
+					}
+				]
+			}`
 		})
 
 		JustBeforeEach(func() {
@@ -65,6 +85,16 @@ var _ = Describe("AppHandler", func() {
 				HealthCheckType:         "http",
 				HealthCheckHTTPEndpoint: "/healthz",
 				HealthCheckTimeoutMs:    400,
+				VolumeMounts: []cf.VolumeMount{
+					{
+						ContainerDir: "/var/vcap/data/e1df89b4-33de-4d72-b471-5495222177c8",
+						Shared: cf.SharedVolumeConfig{
+							MountConfig: cf.VolumeMountConfig{
+								Name: "vol1",
+							},
+						},
+					},
+				},
 			}
 
 			Expect(bifrost.TransferCallCount()).To(Equal(1))

--- a/handler/app_handler_test.go
+++ b/handler/app_handler_test.go
@@ -83,7 +83,7 @@ var _ = Describe("AppHandler", func() {
 				VolumeMounts: []cf.VolumeMount{
 					{
 						MountDir: "/var/vcap/data/e1df89b4-33de-4d72-b471-5495222177c8",
-						VolumeId: "vol1",
+						VolumeID: "vol1",
 					},
 				},
 			}

--- a/k8s/statefulset.go
+++ b/k8s/statefulset.go
@@ -216,6 +216,24 @@ func (m *StatefulSetDesirer) toStatefulSet(lrp *opi.LRP) *v1beta2.StatefulSet {
 	livenessProbe := m.LivenessProbeCreator(lrp)
 	readinessProbe := m.ReadinessProbeCreator(lrp)
 
+	var volumes []v1.Volume
+	var volumeMounts []v1.VolumeMount
+
+	for _, vm := range lrp.VolumeMounts {
+		volumes = append(volumes, v1.Volume{
+			Name: vm.ClaimName,
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: vm.ClaimName,
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      vm.ClaimName,
+			MountPath: vm.MountPath,
+		})
+	}
+
 	statefulSet := &v1beta2.StatefulSet{
 		Spec: v1beta2.StatefulSetSpec{
 			Replicas: int32ptr(lrp.TargetInstances),
@@ -240,8 +258,10 @@ func (m *StatefulSetDesirer) toStatefulSet(lrp *opi.LRP) *v1beta2.StatefulSet {
 							},
 							LivenessProbe:  livenessProbe,
 							ReadinessProbe: readinessProbe,
+							VolumeMounts:   volumeMounts,
 						},
 					},
+					Volumes: volumes,
 				},
 			},
 		},

--- a/models/cf/models.go
+++ b/models/cf/models.go
@@ -1,7 +1,5 @@
 package cf
 
-import "encoding/json"
-
 const (
 	VcapAppName   = "application_name"
 	VcapVersion   = "version"
@@ -21,36 +19,9 @@ type VcapApp struct {
 	SpaceName string   `json:"space_name"`
 }
 
-type VolumeMountConfig struct {
-	Name string `json:"name"`
-}
-
-type SharedVolumeConfig struct {
-	MountConfig VolumeMountConfig `json:"mount_config"`
-}
-
-func (svc *SharedVolumeConfig) UnmarshalJSON(b []byte) error {
-	var data struct {
-		MountConfig string `json:"mount_config"`
-	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
-		return err
-	}
-
-	var volumeMountConfig VolumeMountConfig
-	err = json.Unmarshal([]byte(data.MountConfig), &volumeMountConfig)
-	if err != nil {
-		return err
-	}
-
-	svc.MountConfig = volumeMountConfig
-	return nil
-}
-
 type VolumeMount struct {
-	ContainerDir string             `json:"container_dir"`
-	Shared       SharedVolumeConfig `json:"shared"`
+	VolumeId string `json:"volume_id"`
+	MountDir string `json:"mount_dir"`
 }
 
 type DesireLRPRequest struct {

--- a/models/cf/models.go
+++ b/models/cf/models.go
@@ -20,7 +20,7 @@ type VcapApp struct {
 }
 
 type VolumeMount struct {
-	VolumeId string `json:"volume_id"`
+	VolumeID string `json:"volume_id"`
 	MountDir string `json:"mount_dir"`
 }
 

--- a/opi/model.go
+++ b/opi/model.go
@@ -19,6 +19,12 @@ type LRP struct {
 	TargetInstances  int
 	RunningInstances int
 	Metadata         map[string]string
+	VolumeMounts     []VolumeMount
+}
+
+type VolumeMount struct {
+	MountPath string
+	ClaimName string
 }
 
 type Instance struct {


### PR DESCRIPTION
This commit adds experimental (first cut) support for Cloud Foundry Volume Service Brokers to the Eirini server.

Overall the units and cloud controller integration tests are green.  We still need to run a manual "acceptance" test in the Eirini team's environment to ensure we haven't broken anything.  In parallel, Persi team to run tests of volume service bindings in our environment.   

Longer-term we need to decide how this will be tested moving forwards.  Initial discussions seem to conclude that a subset of PATS (Persi Acceptance Tests) in CATs might be a viable approach.

@mnitchev 