### PR TITLE
Use droplet GUID and droplet Hash to identify OCI images

### DIFF
--- a/bifrost/convert.go
+++ b/bifrost/convert.go
@@ -89,11 +89,11 @@ func (c *DropletToImageConverter) dropletToImageURI(request cf.DesireLRPRequest,
 		return "", err
 	}
 
-	if err = c.pushToRegistry(vcap, request.DropletGUID, dropletBytes); err != nil {
+	if err = c.pushToRegistry(vcap, request.DropletHash, dropletBytes); err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s/cloudfoundry/app-name:%s", c.registryIP, request.DropletGUID), nil
+	return fmt.Sprintf("%s/cloudfoundry/%s:%s", c.registryIP, request.DropletGUID, request.DropletHash), nil
 }
 
 func (c *DropletToImageConverter) pushToRegistry(vcap cf.VcapApp, dropletGUID string, dropletBytes []byte) error {

--- a/bifrost/convert_test.go
+++ b/bifrost/convert_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Convert CC DesiredApp into an opi LRP", func() {
 				})
 
 				It("should convert droplet apps via the special registry URL", func() {
-					Expect(lrp.Image).To(Equal("eirini-registry.service.cf.internal/cloudfoundry/app-name:the-droplet-guid"))
+					Expect(lrp.Image).To(Equal("eirini-registry.service.cf.internal/cloudfoundry/the-droplet-guid:the-droplet-hash"))
 				})
 
 				verifyLRPConvertedSuccessfully()


### PR DESCRIPTION
Guys, we need to make another minor adjustment to how we identify OCI images. The way Cloud Controller (and therefore Bits-Service) stores droplets is:
```
/cc-droplets/so/me/some-droplet-guid/the-droplet-hash
```
So this change adjusts this and makes both things available to us.

/cc @JulzDiverse @suhlig 
