### PR TITLE
Stop the route emitter logging directly to stdout

### DIFF
--- a/cmd/opi/cmd/connect.go
+++ b/cmd/opi/cmd/connect.go
@@ -183,7 +183,7 @@ func launchRouteEmitter(namespace, natsPassword, natsIP string) {
 	workChan := make(chan *route.Message)
 	instanceInformer := k8sroute.NewInstanceChangeInformer(clientset, syncPeriod, namespace)
 	uriInformer := k8sroute.NewURIChangeInformer(clientset, syncPeriod, namespace)
-	re := route.NewEmitter(&route.NATSPublisher{NatsClient: nc}, workChan, &route.SimpleLoopScheduler{})
+	re := route.NewEmitter(&route.NATSPublisher{NatsClient: nc}, workChan, &route.SimpleLoopScheduler{}, os.Stdout)
 
 	go re.Start()
 	go instanceInformer.Start(workChan)


### PR DESCRIPTION
The route emitter structure has a few `fmt.Println`s sprinkled around. This is not ideal for a couple of reasons:
1. When unit testing, _expected_ error messages get printed out to the test `stdout`, which is confusing when all the tests are actually passing.
2. Having some library depths print to stdio streams is pretty annoying, there's no way to turn it off.

This PR introduces a log to the `Emitter` struct that can be injected. In tests we then multiwriter to a buffer we can assert on (turns out, these error logs were not actually being tested), and to the GinkgoWriter, so if a test fails we still get the output.

A few further notes on this:
 - Errors probably shouldn't be going to `stdout` at all, but I didn't change it to `stderr` because that would be a behavioural change.
 - It's probably better to have some real smarter `logger` interface, but that can be changed later.
 - Because the eirini codebase favours constructors with private struct fields, unfortunately the log must always be injected, rather than having an opinionated default with a struct field that can be overridden.

This problem is also in the `metrics` emitter, but I didn't fix it there in case you reject this.