### PR TITLE
Enable Eirini to run outside of a k8s cluster

### DIFF
--- a/cmd/opi/cmd/connect.go
+++ b/cmd/opi/cmd/connect.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"code.cloudfoundry.org/eirini"
@@ -154,16 +153,8 @@ func initBifrost(cfg *eirini.Config) eirini.Bifrost {
 }
 
 func createKubeClient(kubeConfigPath string) kubernetes.Interface {
-	var config *rest.Config
-	var err error
-
-	if kubeConfigPath != "" {
-		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
-		exitWithError(err)
-	} else {
-		config, err = rest.InClusterConfig()
-		exitWithError(err)
-	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	exitWithError(err)
 
 	clientset, err := kubernetes.NewForConfig(config)
 	exitWithError(err)

--- a/models.go
+++ b/models.go
@@ -59,6 +59,8 @@ type Properties struct {
 	CCCertPath string `yaml:"cc_cert_path"`
 	CCKeyPath  string `yaml:"cc_key_path"`
 	CCCAPath   string `yaml:"cc_ca_path"`
+
+	KubeConfigPath string `yaml:"kube_config_path"`
 }
 
 //go:generate counterfeiter . Stager


### PR DESCRIPTION
This PR adds support for the `opi` binary to run outside of the Kubernetes cluster where CF workloads are being scheduled.

Specifically, this PR adds a configurable property to specify a kube config file (`kube_config_path`). If the `kube_config_path` property in the config file does not exist or is empty, then there is no behavior change.

This is a potential solution to issue #51.

There don't seem to be existing unit tests at this level. We can add a new test file here if you want.

Thanks!
Jen & @jspawar