### PR TITLE
Use human-readable timestamps in log messages

### DIFF
--- a/cmd/opi/cmd/connect.go
+++ b/cmd/opi/cmd/connect.go
@@ -95,7 +95,7 @@ func connect(cmd *cobra.Command, args []string) {
 	)
 
 	handlerLogger := lager.NewLogger("handler")
-	handlerLogger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	handlerLogger.RegisterSink(lager.NewPrettySink(os.Stdout, lager.DEBUG))
 	handler := handler.New(bifrost, stager, handlerLogger)
 
 	log.Println("opi connected")
@@ -134,12 +134,12 @@ func initStager(cfg *eirini.Config) eirini.Stager {
 
 func initBifrost(cfg *eirini.Config) eirini.Bifrost {
 	syncLogger := lager.NewLogger("bifrost")
-	syncLogger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	syncLogger.RegisterSink(lager.NewPrettySink(os.Stdout, lager.DEBUG))
 	kubeNamespace := cfg.Properties.KubeNamespace
 	clientset := cmdcommons.CreateKubeClient(cfg.Properties.KubeConfigPath)
 	desirer := k8s.NewStatefulSetDesirer(clientset, kubeNamespace, cfg.Properties.RootfsVersion)
 	convertLogger := lager.NewLogger("convert")
-	convertLogger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	convertLogger.RegisterSink(lager.NewPrettySink(os.Stdout, lager.DEBUG))
 	registryIP := cfg.Properties.RegistryAddress
 	converter := bifrost.NewConverter(convertLogger, registryIP)
 


### PR DESCRIPTION
Instead of prefixing log messages with UNIX Epoch time, which is hard for humans to understand at a glance, use a human readable timestamp format that is also computer-friendly (RFC 3339)

So instead of seeing: 

> { "source": "my-app", "message": "doing-stuff", "data": { "informative": true }, "timestamp": 1556306603, "log_level": 1 }

You should now see:

> { "source": "my-app", "message": "doing-stuff", "data": { "informative": true }, "timestamp": 2019-04-26T19:23:23+00:00, "log_level": 1 }

Thanks,
Jwal + @jenspinney 
