### PR TITLE
Add more logs for errors cases

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -96,12 +96,16 @@ func (b *Bifrost) Stop(ctx context.Context, identifier opi.LRPIdentifier) error 
 
 func (b *Bifrost) StopInstance(ctx context.Context, identifier opi.LRPIdentifier, index uint) error {
 	err := b.Desirer.StopInstance(identifier, index)
+	if err != nil {
+		b.Logger.Error("failed-to-stop-instance", err, lager.Data{"process-guid": identifier.GUID})
+	}
 	return errors.Wrap(err, "desirer failed to stop instance")
 }
 
 func (b *Bifrost) GetInstances(ctx context.Context, identifier opi.LRPIdentifier) ([]*cf.Instance, error) {
 	opiInstances, err := b.Desirer.GetInstances(identifier)
 	if err != nil {
+		b.Logger.Error("failed-to-get-instances", err, lager.Data{"process-guid": identifier.GUID})
 		return []*cf.Instance{}, errors.Wrap(err, fmt.Sprintf("failed to get instances for app with guid: %s", identifier.GUID))
 	}
 

--- a/cmd/opi/cmd/connect.go
+++ b/cmd/opi/cmd/connect.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -98,8 +97,8 @@ func connect(cmd *cobra.Command, args []string) {
 	handlerLogger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
 	handler := handler.New(bifrost, stager, handlerLogger)
 
-	log.Println("opi connected")
-	log.Fatal(http.ListenAndServe("0.0.0.0:8085", handler))
+	handlerLogger.Info("opi-connected")
+	handlerLogger.Fatal("opi-crashed", http.ListenAndServe("0.0.0.0:8085", handler))
 }
 
 func initStager(cfg *eirini.Config) eirini.Stager {
@@ -137,7 +136,9 @@ func initBifrost(cfg *eirini.Config) eirini.Bifrost {
 	syncLogger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
 	kubeNamespace := cfg.Properties.KubeNamespace
 	clientset := cmdcommons.CreateKubeClient(cfg.Properties.KubeConfigPath)
-	desirer := k8s.NewStatefulSetDesirer(clientset, kubeNamespace, cfg.Properties.RootfsVersion)
+	desireLogger := lager.NewLogger("desirer")
+	desireLogger.RegisterSink(lager.NewPrettySink(os.Stdout, lager.DEBUG))
+	desirer := k8s.NewStatefulSetDesirer(clientset, kubeNamespace, cfg.Properties.RootfsVersion, desireLogger)
 	convertLogger := lager.NewLogger("convert")
 	convertLogger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
 	registryIP := cfg.Properties.RegistryAddress
@@ -174,7 +175,9 @@ func launchRouteEmitter(kubeConfigPath, namespace, natsPassword, natsIP string) 
 	workChan := make(chan *route.Message)
 	instanceInformer := k8sroute.NewInstanceChangeInformer(clientset, syncPeriod, namespace)
 	uriInformer := k8sroute.NewURIChangeInformer(clientset, syncPeriod, namespace)
-	re := route.NewEmitter(&route.NATSPublisher{NatsClient: nc}, workChan, &route.SimpleLoopScheduler{}, os.Stdout)
+	emitterLogger := lager.NewLogger("route-emitter")
+	emitterLogger.RegisterSink(lager.NewPrettySink(os.Stdout, lager.DEBUG))
+	re := route.NewEmitter(&route.NATSPublisher{NatsClient: nc}, workChan, &route.SimpleLoopScheduler{}, emitterLogger)
 
 	go re.Start()
 	go instanceInformer.Start(workChan)
@@ -201,7 +204,9 @@ func launchEventReporter(kubeConfigPath, uri, ca, cert, key, namespace string) {
 	client := cc_client.NewCcClient(uri, tlsConf)
 	reporter := events.NewCrashReporter(work, &route.SimpleLoopScheduler{}, client, lager.NewLogger("instance-crash-reporter"))
 	clientset := cmdcommons.CreateKubeClient(kubeConfigPath)
-	crashInformer := k8sevent.NewCrashInformer(clientset, 0, namespace, work, make(chan struct{}))
+	crashLogger := lager.NewLogger("instance-crash-informer")
+	crashLogger.RegisterSink(lager.NewPrettySink(os.Stdout, lager.DEBUG))
+	crashInformer := k8sevent.NewCrashInformer(clientset, 0, namespace, work, make(chan struct{}), crashLogger)
 
 	go crashInformer.Start()
 	go reporter.Run()

--- a/handler/app_handler.go
+++ b/handler/app_handler.go
@@ -158,6 +158,7 @@ func (a *App) GetInstances(w http.ResponseWriter, r *http.Request, ps httprouter
 		Version: ps.ByName("version_guid"),
 	}
 	instances, err := a.bifrost.GetInstances(r.Context(), identifier)
+	a.logError("get-instances-failed", err)
 	response := a.createGetInstancesResponse(identifier.ProcessGUID(), instances, err)
 
 	err = json.NewEncoder(w).Encode(response)

--- a/integration/rootfs_patcher_test.go
+++ b/integration/rootfs_patcher_test.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/eirini/k8s/utils"
 	"code.cloudfoundry.org/eirini/opi"
 	"code.cloudfoundry.org/eirini/rootfspatcher"
+	"code.cloudfoundry.org/lager/lagertest"
 )
 
 var _ = Describe("RootfsPatcher", func() {
@@ -26,6 +27,7 @@ var _ = Describe("RootfsPatcher", func() {
 			clientset,
 			namespace,
 			"old_rootfsversion",
+			lagertest.NewTestLogger("test-logger"),
 		)
 		odinLRP = createLRP("ödin")
 		thorLRP = createLRP("thor")

--- a/integration/statefulset_test.go
+++ b/integration/statefulset_test.go
@@ -6,6 +6,7 @@ import (
 	"code.cloudfoundry.org/eirini/k8s"
 	"code.cloudfoundry.org/eirini/models/cf"
 	"code.cloudfoundry.org/eirini/opi"
+	"code.cloudfoundry.org/lager/lagertest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,6 +40,7 @@ var _ = Describe("StatefulSet Manager", func() {
 			clientset,
 			namespace,
 			"rootfsversion",
+			lagertest.NewTestLogger("test-logger"),
 		)
 	})
 

--- a/k8s/informers/event/crash_test.go
+++ b/k8s/informers/event/crash_test.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/eirini/events"
 	. "code.cloudfoundry.org/eirini/k8s/informers/event"
 	"code.cloudfoundry.org/eirini/models/cf"
+	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/runtimeschema/cc_messages"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -44,7 +45,7 @@ var _ = Describe("Event", func() {
 		informerStopper = make(chan struct{})
 
 		client = fake.NewSimpleClientset()
-		crashInformer = NewCrashInformer(client, 0, namespace, reportChan, informerStopper)
+		crashInformer = NewCrashInformer(client, 0, namespace, reportChan, informerStopper, lagertest.NewTestLogger("test-logger"))
 
 		watcher = watch.NewFake()
 		fakecs := client.(*fake.Clientset)

--- a/k8s/statefulset_test.go
+++ b/k8s/statefulset_test.go
@@ -15,6 +15,7 @@ import (
 	"code.cloudfoundry.org/eirini/opi"
 	"code.cloudfoundry.org/eirini/rootfspatcher"
 	"code.cloudfoundry.org/eirini/util/utilfakes"
+	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -77,6 +78,7 @@ var _ = Describe("Statefulset", func() {
 			LivenessProbeCreator:  livenessProbeCreator.Spy,
 			ReadinessProbeCreator: readinessProbeCreator.Spy,
 			Hasher:                hasher,
+			Logger:                lagertest.NewTestLogger("test-logger"),
 		}
 	})
 


### PR DESCRIPTION
We've found it helpful to have some more logging in error cases, so we've added a few log lines to various parts of eirini.

We've also converted a few places that used `Printf` or the Golang built-in logging library to use `lager.Logger` instead for consistency (and so that lager-log-processing tools like `veritas` work well).

We updated tests to reflect these changes. We also needed to pass in a test logger in a couple places where we've updated the function signature to expect a logger.

Thanks!
Jen + @jspawar 