### PR TITLE
Panic if exiting with an error

### DIFF
--- a/cmd/commons.go
+++ b/cmd/commons.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
@@ -34,7 +31,6 @@ func CreateKubeClient(kubeConfigPath string) kubernetes.Interface {
 
 func ExitWithError(err error) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-		os.Exit(1)
+		panic(err)
 	}
 }


### PR DESCRIPTION
Hi Eirini!

When using the opi binary, I've had a hard time sometimes finding where an error came from if it was generated via `ExitWithError`. This PR modifies ExitWithError to `panic`, which will show a stack trace and run any deferred clean up before exiting. This seems both safer (because of the `defer` blocks getting run) and easier for debugging, since a stack trace will be printed.

Thanks,
Jen