### PR TITLE
keep the staging job when it fails

### DIFF
--- a/stager/stager.go
+++ b/stager/stager.go
@@ -96,6 +96,10 @@ func (s *Stager) CompleteStaging(task *models.TaskCallbackResponse) error {
 		return err
 	}
 
+	if task.Failed {
+		return nil
+	}
+
 	return s.Desirer.Delete(task.TaskGuid)
 }
 

--- a/stager/stager_test.go
+++ b/stager/stager_test.go
@@ -203,6 +203,10 @@ var _ = Describe("Stager", func() {
 			It("should post the response", func() {
 				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
+
+			It("should not delete the task", func() {
+				Expect(taskDesirer.DeleteCallCount()).To(Equal(0))
+			})
 		})
 
 		Context("and the staging result is not a valid json", func() {


### PR DESCRIPTION
Keeping the failed job allows for later inspection of failed staging to see the failure reason and debug.

[#166678515](https://www.pivotaltracker.com/story/show/166678515)
