### PR TITLE
Allow RTR messages to appear in cf logs stream

### DIFF
--- a/k8s/informers/route/instance_informer_test.go
+++ b/k8s/informers/route/instance_informer_test.go
@@ -47,7 +47,10 @@ var _ = Describe("InstanceChangeInformer", func() {
 	createPod := func(name string) *corev1.Pod {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        name,
+				Name: name,
+				Labels: map[string]string{
+					"guid": name + "-guid",
+				},
 				Annotations: map[string]string{cf.ProcessGUID: name + "-anno"},
 				OwnerReferences: []metav1.OwnerReference{
 					{
@@ -161,7 +164,7 @@ var _ = Describe("InstanceChangeInformer", func() {
 					RegisteredRoutes: []string{"mr-stateful.50.60.70.80.nip.io"},
 				},
 
-				Name:       "mr-stateful-0",
+				Name:       "mr-stateful-0-guid",
 				InstanceID: "mr-stateful-0",
 				Address:    "10.20.30.40",
 				Port:       8080,
@@ -180,7 +183,7 @@ var _ = Describe("InstanceChangeInformer", func() {
 					RegisteredRoutes: []string{"mr-bombastic.50.60.70.80.nip.io"},
 				},
 
-				Name:       "mr-stateful-0",
+				Name:       "mr-stateful-0-guid",
 				InstanceID: "mr-stateful-0",
 				Address:    "10.20.30.40",
 				Port:       6565,
@@ -235,7 +238,7 @@ var _ = Describe("InstanceChangeInformer", func() {
 					RegisteredRoutes: []string{"mr-stateful.50.60.70.80.nip.io"},
 				},
 
-				Name:       "mr-stateful-0",
+				Name:       "mr-stateful-0-guid",
 				InstanceID: "mr-stateful-0",
 				Address:    "10.20.30.40",
 				Port:       8080,
@@ -290,7 +293,7 @@ var _ = Describe("InstanceChangeInformer", func() {
 					UnregisteredRoutes: []string{"mr-bombastic.50.60.70.80.nip.io"},
 				},
 
-				Name:       "mr-stateful-0",
+				Name:       "mr-stateful-0-guid",
 				InstanceID: "mr-stateful-0",
 				Address:    "10.20.30.40",
 				Port:       6565,
@@ -337,7 +340,7 @@ var _ = Describe("InstanceChangeInformer", func() {
 						UnregisteredRoutes: []string{"mr-bombastic.50.60.70.80.nip.io"},
 					},
 
-					Name:       "mr-stateful-0",
+					Name:       "mr-stateful-0-guid",
 					InstanceID: "mr-stateful-0",
 					Address:    "10.20.30.40",
 					Port:       6565,

--- a/k8s/informers/route/uri_informer.go
+++ b/k8s/informers/route/uri_informer.go
@@ -45,7 +45,7 @@ func NewRouteMessage(pod *v1.Pod, port uint32, routes eiriniroute.Routes) (*eiri
 		Routes: eiriniroute.Routes{
 			UnregisteredRoutes: routes.UnregisteredRoutes,
 		},
-		Name:       pod.Name,
+		Name:       pod.Labels["guid"],
 		InstanceID: pod.Name,
 		Address:    pod.Status.PodIP,
 		Port:       port,

--- a/k8s/informers/route/uri_informer_test.go
+++ b/k8s/informers/route/uri_informer_test.go
@@ -56,6 +56,7 @@ var _ = Describe("URIChangeInformer", func() {
 				},
 				Labels: map[string]string{
 					"name": "the-app-name",
+					"guid": name + "-guid",
 				},
 			},
 			Spec: v1.PodSpec{
@@ -183,7 +184,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register the first new route for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -197,7 +198,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register the second new route for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-fantastic.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -210,7 +211,7 @@ var _ = Describe("URIChangeInformer", func() {
 		})
 		It("should register the third new route for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-boombastic.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -224,7 +225,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register the first new route for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -238,7 +239,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register the second new route for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-fantastic.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -252,7 +253,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register the third new route for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-boombastic.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -287,7 +288,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 			It("should not send routes for the pod", func() {
 				Consistently(workChan, routeMessageTimeout).ShouldNot(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Name": Equal("mr-stateful-0"),
+					"Name": Equal("mr-stateful-0-guid"),
 				}))))
 			})
 
@@ -300,13 +301,13 @@ var _ = Describe("URIChangeInformer", func() {
 
 			It("should not send routes for the first pod", func() {
 				Consistently(workChan, routeMessageTimeout).ShouldNot(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Name": Equal("mr-stateful-0"),
+					"Name": Equal("mr-stateful-0-guid"),
 				}))))
 			})
 
 			It("should register routes for the second pod", func() {
 				Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Name": Equal("mr-stateful-1"),
+					"Name": Equal("mr-stateful-1-guid"),
 					"Routes": MatchFields(IgnoreExtras, Fields{
 						"RegisteredRoutes": Not(BeEmpty()),
 					}),
@@ -339,7 +340,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister the deleted route for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-boombastic.50.60.70.80.nip.io"),
@@ -353,7 +354,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister the deleted route for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-boombastic.50.60.70.80.nip.io"),
@@ -382,7 +383,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister the first changed route for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -396,7 +397,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister the firt changed route for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-stateful.50.60.70.80.nip.io"),
@@ -410,7 +411,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister the first changed route for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -424,7 +425,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister the first changed route for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-stateful.50.60.70.80.nip.io"),
@@ -454,7 +455,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register both routes in a single message", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io", "mr-boombastic.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -468,7 +469,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register both routes in a single message", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io", "mr-boombastic.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -524,7 +525,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should still register the new route", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -608,14 +609,14 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should not send routes for the pod", func() {
 			Consistently(workChan, routeMessageTimeout).ShouldNot(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Name":             Equal("mr-stateful-0"),
+				"Name":             Equal("mr-stateful-0-guid"),
 				"RegisteredRoutes": Not(BeEmpty()),
 			}))))
 		})
 
 		It("should unregister the deleted route for the pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-stateful.50.60.70.80.nip.io"),
@@ -629,7 +630,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should register the new route for the other pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   ConsistOf("mr-stateful.50.60.70.80.nip.io"),
 					"UnregisteredRoutes": BeEmpty(),
@@ -643,7 +644,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister the deleted route for the other pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-stateful.50.60.70.80.nip.io"),
@@ -665,7 +666,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister all routes for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-stateful.50.60.70.80.nip.io"),
@@ -679,7 +680,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister all routes for the first pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-0"),
+				"Name": Equal("mr-stateful-0-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-boombastic.50.60.70.80.nip.io"),
@@ -693,7 +694,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister all routes for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-stateful.50.60.70.80.nip.io"),
@@ -707,7 +708,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 		It("should unregister all routes for the second pod", func() {
 			Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-				"Name": Equal("mr-stateful-1"),
+				"Name": Equal("mr-stateful-1-guid"),
 				"Routes": MatchAllFields(Fields{
 					"RegisteredRoutes":   BeEmpty(),
 					"UnregisteredRoutes": ConsistOf("mr-boombastic.50.60.70.80.nip.io"),
@@ -726,7 +727,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 			It("should unregister all routes for the first pod", func() {
 				Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-					"Name": Equal("mr-stateful-0"),
+					"Name": Equal("mr-stateful-0-guid"),
 					"Routes": MatchAllFields(Fields{
 						"RegisteredRoutes":   BeEmpty(),
 						"UnregisteredRoutes": ConsistOf("mr-stateful.50.60.70.80.nip.io"),
@@ -740,7 +741,7 @@ var _ = Describe("URIChangeInformer", func() {
 
 			It("should unregister all routes for the first pod", func() {
 				Eventually(workChan, routeMessageTimeout).Should(Receive(PointTo(MatchAllFields(Fields{
-					"Name": Equal("mr-stateful-0"),
+					"Name": Equal("mr-stateful-0-guid"),
 					"Routes": MatchAllFields(Fields{
 						"RegisteredRoutes":   BeEmpty(),
 						"UnregisteredRoutes": ConsistOf("mr-boombastic.50.60.70.80.nip.io"),

--- a/k8s/route_collector.go
+++ b/k8s/route_collector.go
@@ -50,7 +50,7 @@ func (c RouteCollector) Collect() ([]route.Message, error) {
 		for _, r := range routes {
 			routeMessage := route.Message{
 				InstanceID: p.Name,
-				Name:       p.Name,
+				Name:       p.Labels["guid"],
 				Address:    p.Status.PodIP,
 				Port:       uint32(r.Port),
 				TLSPort:    0,

--- a/k8s/route_collector_test.go
+++ b/k8s/route_collector_test.go
@@ -41,6 +41,9 @@ var _ = Describe("RouteCollector", func() {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
+				Labels: map[string]string{
+					"guid": name + "-guid",
+				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: "apps/v1",
 					Kind:       "StatefulSet",
@@ -119,7 +122,7 @@ var _ = Describe("RouteCollector", func() {
 			Expect(routeMessages).To(ConsistOf([]route.Message{
 				{
 					InstanceID: "pod-11",
-					Name:       "pod-11",
+					Name:       "pod-11-guid",
 					Address:    "10.0.0.1",
 					Port:       80,
 					TLSPort:    0,
@@ -129,7 +132,7 @@ var _ = Describe("RouteCollector", func() {
 				},
 				{
 					InstanceID: "pod-21",
-					Name:       "pod-21",
+					Name:       "pod-21-guid",
 					Address:    "10.0.0.2",
 					Port:       9000,
 					TLSPort:    0,
@@ -139,7 +142,7 @@ var _ = Describe("RouteCollector", func() {
 				},
 				{
 					InstanceID: "pod-22",
-					Name:       "pod-22",
+					Name:       "pod-22-guid",
 					Address:    "10.0.0.3",
 					Port:       9000,
 					TLSPort:    0,
@@ -163,7 +166,7 @@ var _ = Describe("RouteCollector", func() {
 			It("should return a route message for each registered route", func() {
 				Expect(routeMessages).To(ContainElement(route.Message{
 					InstanceID: "pod-11",
-					Name:       "pod-11",
+					Name:       "pod-11-guid",
 					Address:    "10.0.0.1",
 					Port:       80,
 					TLSPort:    0,
@@ -173,7 +176,7 @@ var _ = Describe("RouteCollector", func() {
 				}))
 				Expect(routeMessages).To(ContainElement(route.Message{
 					InstanceID: "pod-11",
-					Name:       "pod-11",
+					Name:       "pod-11-guid",
 					Address:    "10.0.0.1",
 					Port:       443,
 					TLSPort:    0,
@@ -193,7 +196,7 @@ var _ = Describe("RouteCollector", func() {
 				Expect(routeMessages).To(ConsistOf([]route.Message{
 					{
 						InstanceID: "pod-21",
-						Name:       "pod-21",
+						Name:       "pod-21-guid",
 						Address:    "10.0.0.2",
 						Port:       9000,
 						TLSPort:    0,
@@ -203,7 +206,7 @@ var _ = Describe("RouteCollector", func() {
 					},
 					{
 						InstanceID: "pod-22",
-						Name:       "pod-22",
+						Name:       "pod-22-guid",
 						Address:    "10.0.0.3",
 						Port:       9000,
 						TLSPort:    0,
@@ -225,7 +228,7 @@ var _ = Describe("RouteCollector", func() {
 				Expect(routeMessages).To(ConsistOf([]route.Message{
 					{
 						InstanceID: "pod-21",
-						Name:       "pod-21",
+						Name:       "pod-21-guid",
 						Address:    "10.0.0.2",
 						Port:       9000,
 						TLSPort:    0,
@@ -235,7 +238,7 @@ var _ = Describe("RouteCollector", func() {
 					},
 					{
 						InstanceID: "pod-22",
-						Name:       "pod-22",
+						Name:       "pod-22-guid",
 						Address:    "10.0.0.3",
 						Port:       9000,
 						TLSPort:    0,
@@ -307,7 +310,7 @@ var _ = Describe("RouteCollector", func() {
 				Expect(routeMessages).To(Equal([]route.Message{
 					{
 						InstanceID: "pod-11",
-						Name:       "pod-11",
+						Name:       "pod-11-guid",
 						Address:    "10.0.0.1",
 						Port:       80,
 						TLSPort:    0,
@@ -329,7 +332,7 @@ var _ = Describe("RouteCollector", func() {
 				Expect(routeMessages).To(Equal([]route.Message{
 					{
 						InstanceID: "pod-11",
-						Name:       "pod-11",
+						Name:       "pod-11-guid",
 						Address:    "10.0.0.1",
 						Port:       80,
 						TLSPort:    0,
@@ -351,7 +354,7 @@ var _ = Describe("RouteCollector", func() {
 				Expect(routeMessages).To(Equal([]route.Message{
 					{
 						InstanceID: "pod-11",
-						Name:       "pod-11",
+						Name:       "pod-11-guid",
 						Address:    "10.0.0.1",
 						Port:       80,
 						TLSPort:    0,


### PR DESCRIPTION
Added a fix so that `RTR` messages appear in the output of `cf logs` for this story in the Eirini backlog: https://www.pivotaltracker.com/story/show/165745052

Had to modify the NATS messages to the gorouter to advertise the app by its GUID instead of the pod's name.

Thanks,
Jwal + @madamkiwi 