### PR TITLE
Modify staging logic to optionally add HostAliases to corresponding Kubernetes jobs

### DIFF
--- a/k8s/desiretask.go
+++ b/k8s/desiretask.go
@@ -63,11 +63,13 @@ func (d *TaskDesirer) Delete(name string) error {
 func (d *TaskDesirer) toStagingJob(task *opi.StagingTask) *batch.Job {
 	job := toJob(task.Task)
 
-	job.Spec.Template.Spec.HostAliases = []v1.HostAlias{
-		{
-			IP:        d.CCUploaderIP,
-			Hostnames: []string{eirini.CCUploaderInternalURL},
-		},
+	if d.CCUploaderIP != "" {
+		job.Spec.Template.Spec.HostAliases = []v1.HostAlias{
+			{
+				IP:        d.CCUploaderIP,
+				Hostnames: []string{eirini.CCUploaderInternalURL},
+			},
+		}
 	}
 
 	secretsVolume := v1.Volume{

--- a/k8s/desiretask_test.go
+++ b/k8s/desiretask_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Desiretask", func() {
 			}
 		})
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			Expect(desirer.DesireStaging(stagingTask)).To(Succeed())
 		})
 
@@ -248,6 +248,19 @@ var _ = Describe("Desiretask", func() {
 			It("should return an error", func() {
 				Expect(desirer.DesireStaging(stagingTask)).To(MatchError(ContainSubstring("job already exists")))
 
+			})
+		})
+
+		Context("when the CC Uploader IP is not provided", func() {
+			BeforeEach(func() {
+				desirer.(*TaskDesirer).CCUploaderIP = ""
+			})
+
+			It("should create a Kubernetes job without any HostAliases", func() {
+				job, getErr := fakeClient.BatchV1().Jobs(Namespace).Get("the-stage-is-yours", meta_v1.GetOptions{})
+				Expect(getErr).ToNot(HaveOccurred())
+
+				Expect(job.Spec.Template.Spec.HostAliases).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
The Kubernetes job the staging logic creates doesn't always need HostAliases configured if the cluster Eirini is targeting has some means of resolving the value of `eirini.CCUploaderInternalURL` to the actual CC Uploader(s), such as BOSH DNS. 

Also, specifically if BOSH DNS is used with the default BOSH DNS aliases that `cf-deployment` configures, creating HostAliases for the staging job will conflict with the BOSH DNS resolution of `cc-uploader.service.cf.internal` so this change would also prevent that conflict. 

It might make more sense in the future to make the `eirini.CCUploaderInternalURL` property's value configurable so that it can be resolved by other DNS solutions such as maybe Kubernetes DNS. 

Thanks,
Jwal