### PR TITLE
Support multicontainer pods for status and crash reports

### DIFF
--- a/k8s/informers/event/crash_report_generator.go
+++ b/k8s/informers/event/crash_report_generator.go
@@ -24,23 +24,20 @@ func (DefaultCrashReportGenerator) Generate(pod *v1.Pod, clientset kubernetes.In
 		return events.CrashReport{}, false
 	}
 
-	terminated := pod.Status.ContainerStatuses[0].State.Terminated
-	if terminated != nil && terminated.ExitCode != 0 {
-		return generateReportForTerminatedPod(pod, clientset, logger)
+	if status := getTerminatedContainerStatusIfAny(pod.Status.ContainerStatuses); status != nil {
+		return generateReportForTerminatedPod(pod, status, clientset, logger)
 	}
 
-	waiting := pod.Status.ContainerStatuses[0].State.Waiting
-	if waiting != nil && waiting.Reason == CrashLoopBackOff {
-		container := pod.Status.ContainerStatuses[0]
+	if container := getCrashedContainerStatusIfAny(pod.Status.ContainerStatuses); container != nil {
 		exitStatus := int(container.LastTerminationState.Terminated.ExitCode)
 		exitDescription := container.LastTerminationState.Terminated.Reason
 		crashTimestamp := int64(container.LastTerminationState.Terminated.StartedAt.Second())
-		return generateReport(pod, waiting.Reason, exitStatus, exitDescription, crashTimestamp)
+		return generateReport(pod, container.State.Waiting.Reason, exitStatus, exitDescription, crashTimestamp, int(container.RestartCount))
 	}
 	return events.CrashReport{}, false
 }
 
-func generateReportForTerminatedPod(pod *v1.Pod, clientset kubernetes.Interface, logger lager.Logger) (events.CrashReport, bool) {
+func generateReportForTerminatedPod(pod *v1.Pod, status *v1.ContainerStatus, clientset kubernetes.Interface, logger lager.Logger) (events.CrashReport, bool) {
 	podEvents, err := k8s.GetEvents(clientset.CoreV1().Events(pod.Namespace), *pod)
 	if err != nil {
 		logger.Error("failed-to-get-k8s-events", err, lager.Data{"guid": pod.Annotations[k8s.AnnotationProcessGUID]})
@@ -50,8 +47,9 @@ func generateReportForTerminatedPod(pod *v1.Pod, clientset kubernetes.Interface,
 		return events.CrashReport{}, false
 	}
 
-	terminated := pod.Status.ContainerStatuses[0].State.Terminated
-	return generateReport(pod, terminated.Reason, int(terminated.ExitCode), terminated.Reason, int64(terminated.StartedAt.Second()))
+	terminated := status.State.Terminated
+
+	return generateReport(pod, terminated.Reason, int(terminated.ExitCode), terminated.Reason, int64(terminated.StartedAt.Second()), int(status.RestartCount))
 }
 
 func generateReport(
@@ -60,9 +58,9 @@ func generateReport(
 	exitStatus int,
 	exitDescription string,
 	crashTimestamp int64,
+	restartCount int,
 ) (events.CrashReport, bool) {
 	index, _ := util.ParseAppIndex(pod.Name)
-	container := pod.Status.ContainerStatuses[0]
 
 	return events.CrashReport{
 		ProcessGUID: pod.Annotations[k8s.AnnotationProcessGUID],
@@ -73,7 +71,29 @@ func generateReport(
 			ExitStatus:      exitStatus,
 			ExitDescription: exitDescription,
 			CrashTimestamp:  crashTimestamp,
-			CrashCount:      int(container.RestartCount),
+			CrashCount:      restartCount,
 		},
 	}, true
+}
+
+func getTerminatedContainerStatusIfAny(statuses []v1.ContainerStatus) *v1.ContainerStatus {
+	for _, status := range statuses {
+		terminated := status.State.Terminated
+		if terminated != nil && terminated.ExitCode != 0 {
+			return &status
+		}
+	}
+
+	return nil
+}
+
+func getCrashedContainerStatusIfAny(statuses []v1.ContainerStatus) *v1.ContainerStatus {
+	for _, status := range statuses {
+		waiting := status.State.Waiting
+		if waiting != nil && waiting.Reason == CrashLoopBackOff {
+			return &status
+		}
+	}
+
+	return nil
 }

--- a/k8s/utils/pod_state.go
+++ b/k8s/utils/pod_state.go
@@ -11,44 +11,81 @@ func GetPodState(pod corev1.Pod) string {
 	}
 
 	if podPending(&pod) {
-		if brokenImage(&pod) {
+		if containersHaveBrokenImage(pod.Status.ContainerStatuses) {
 			return opi.CrashedState
 		}
 		return opi.PendingState
 	}
 
-	if podNotReady(&pod) {
-		return opi.PendingState
-	}
-
-	if podCrashed(pod.Status.ContainerStatuses[0]) {
+	if podFailed(&pod) {
 		return opi.CrashedState
 	}
 
-	if podRunning(pod.Status.ContainerStatuses[0]) {
-		return opi.RunningState
+	if podRunning(&pod) {
+		if containersReady(pod.Status.ContainerStatuses) {
+			return opi.RunningState
+		}
+
+		if containersRunning(pod.Status.ContainerStatuses) {
+			return opi.PendingState
+		}
+	}
+
+	if containersFailed(pod.Status.ContainerStatuses) {
+		return opi.CrashedState
 	}
 
 	return opi.UnknownState
 }
 
-func brokenImage(pod *corev1.Pod) bool {
-	status := pod.Status.ContainerStatuses[0]
-	return status.State.Waiting.Reason == "ErrImagePull" || status.State.Waiting.Reason == "ImagePullBackOff"
-}
-
 func podPending(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodPending
 }
-func podNotReady(pod *corev1.Pod) bool {
-	status := pod.Status.ContainerStatuses[0]
-	return (status.State.Running != nil && !status.Ready)
+
+func podFailed(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodFailed
 }
 
-func podCrashed(status corev1.ContainerStatus) bool {
-	return status.State.Waiting != nil || status.State.Terminated != nil
+func podRunning(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning
 }
 
-func podRunning(status corev1.ContainerStatus) bool {
-	return status.State.Running != nil && status.Ready
+func containersHaveBrokenImage(statuses []corev1.ContainerStatus) bool {
+	for _, status := range statuses {
+		if status.State.Waiting.Reason == "ErrImagePull" || status.State.Waiting.Reason == "ImagePullBackOff" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containersFailed(statuses []corev1.ContainerStatus) bool {
+	for _, status := range statuses {
+		if status.State.Waiting != nil || status.State.Terminated != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containersReady(statuses []corev1.ContainerStatus) bool {
+	for _, status := range statuses {
+		if status.State.Running == nil || !status.Ready {
+			return false
+		}
+	}
+
+	return true
+}
+
+func containersRunning(statuses []corev1.ContainerStatus) bool {
+	for _, status := range statuses {
+		if status.State.Running == nil {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
Progress towards #79

We changed the way we determine whether the pod is crashed or running by checking the status of **all containers** on the pod, not only the first one. This required when we inject sidecars into pods.


[#169685576](https://www.pivotaltracker.com/story/show/169685576)

cc @rosenhouse @tcdowney 