### PR TITLE
Increase integration tests timeout limit

### DIFF
--- a/integration/cmd/connect_test.go
+++ b/integration/cmd/connect_test.go
@@ -99,7 +99,7 @@ var _ = Describe("connect command", func() {
 				command := exec.Command(cmdPath, "connect", "-c", "not-found.yml") // #nosec G204
 				session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(session, "5s").Should(gexec.Exit())
+				Eventually(session, "10s").Should(gexec.Exit())
 				Expect(session.ExitCode()).NotTo(BeZero())
 			})
 		})

--- a/integration/opi/opi_suite_test.go
+++ b/integration/opi/opi_suite_test.go
@@ -76,7 +76,7 @@ var _ = BeforeEach(func() {
 	Eventually(func() error {
 		_, getErr := httpClient.Get(url)
 		return getErr
-	}, "5s").Should(Succeed())
+	}, "10s").Should(Succeed())
 })
 
 var _ = AfterEach(func() {


### PR DESCRIPTION
The following has been tested against a local KinD kubernetes cluster.
When run locally the connect and opi-suite tests were producing timeouts, so I increased the time limits. This is purely a change to enable local development.