### PR TITLE
use lrp guid instead of app guid when translating statefulsets

### DIFF
--- a/k8s/mapper.go
+++ b/k8s/mapper.go
@@ -26,7 +26,7 @@ func StatefulSetToLRP(s appsv1.StatefulSet) *opi.LRP {
 
 	return &opi.LRP{
 		LRPIdentifier: opi.LRPIdentifier{
-			GUID:    s.Annotations[AnnotationAppID],
+			GUID:    s.Labels[LabelGUID],
 			Version: s.Annotations[AnnotationVersion],
 		},
 		AppName:          s.Annotations[AnnotationAppName],

--- a/k8s/mapper_test.go
+++ b/k8s/mapper_test.go
@@ -20,6 +20,9 @@ var _ = Describe("Mapper", func() {
 		statefulset := appsv1.StatefulSet{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "baldur",
+				Labels: map[string]string{
+					LabelGUID: "Bald-guid",
+				},
 				Annotations: map[string]string{
 					AnnotationProcessGUID: "Baldur-guid",
 					AnnotationLastUpdated: "last-updated-some-time-ago",
@@ -76,7 +79,7 @@ var _ = Describe("Mapper", func() {
 	})
 
 	It("should set the correct LRP identifier", func() {
-		Expect(lrp.LRPIdentifier.GUID).To(Equal("guid_1234"))
+		Expect(lrp.LRPIdentifier.GUID).To(Equal("Bald-guid"))
 		Expect(lrp.LRPIdentifier.Version).To(Equal("version_1234"))
 	})
 


### PR DESCRIPTION
* we believe this fixes some bugs we've found when trying to get v3 deployments working.
* it generally seems more correct to keep this guid consistent and not entangle it with other CF concepts. 
* these issues appear when a process's guid != its app guid, like after a v3 deployment. prior to rolling deployments, an app's web process and the app itself will always have the same guid. 

[fixes https://www.pivotaltracker.com/story/show/168391143]

Co-authored-by: Connor Braa <cbraa@pivotal.io>
Co-authored-by: Seth Boyles <sboyles@pivotal.io>
