### PR TITLE
Parameterize baseimage in Dockerfiles

### DIFF
--- a/docker/bits-waiter/Dockerfile
+++ b/docker/bits-waiter/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -trimpath -installsuffix cg
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 
 COPY --from=builder /eirini/bits-waiter /bits-waiter
 USER 1001

--- a/docker/event-reporter/Dockerfile
+++ b/docker/event-reporter/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 COPY --from=builder /eirini/event-reporter /usr/local/bin/event-reporter
 USER 1001
 ENTRYPOINT [ "/usr/local/bin/event-reporter", \

--- a/docker/metrics-collector/Dockerfile
+++ b/docker/metrics-collector/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 COPY --from=builder /eirini/metrics-collector /usr/local/bin/metrics-collector
 USER 1001
 ENTRYPOINT [ "/usr/local/bin/metrics-collector", \

--- a/docker/opi/Dockerfile
+++ b/docker/opi/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=cloudfoundry/run:tiny
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM cloudfoundry/run:tiny
+FROM ${baseimage}
 COPY --from=builder /eirini/eirini /workspace/jobs/opi/bin/opi
 USER 1001
 ENTRYPOINT [ "/workspace/jobs/opi/bin/opi", \

--- a/docker/rootfs-patcher/Dockerfile
+++ b/docker/rootfs-patcher/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -trimpath -installsuffix cg
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 
 COPY --from=builder /eirini/rootfs-patcher /rootfs-patcher
 USER 1001

--- a/docker/route-collector/Dockerfile
+++ b/docker/route-collector/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 COPY --from=builder /eirini/route-collector /usr/local/bin/route-collector
 USER 1001
 ENTRYPOINT [ "/usr/local/bin/route-collector", \

--- a/docker/route-pod-informer/Dockerfile
+++ b/docker/route-pod-informer/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 COPY --from=builder /eirini/route-pod-informer /usr/local/bin/route-pod-informer
 USER 1001
 ENTRYPOINT [ "/usr/local/bin/route-pod-informer", \

--- a/docker/route-statefulset-informer/Dockerfile
+++ b/docker/route-statefulset-informer/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 COPY --from=builder /eirini/route-statefulset-informer /usr/local/bin/route-statefulset-informer
 USER 1001
 ENTRYPOINT [ "/usr/local/bin/route-statefulset-informer", \

--- a/docker/staging-reporter/Dockerfile
+++ b/docker/staging-reporter/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=scratch
+
 FROM golang:1.13 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM scratch
+FROM ${baseimage}
 COPY --from=builder /eirini/staging-reporter /usr/local/bin/staging-reporter
 USER 1001
 ENTRYPOINT [ "/usr/local/bin/staging-reporter", \


### PR DESCRIPTION
This PR will allow the building of the images on a different base. For example, we need to build all the images with a SLE (SUSE Linux Enterprise) base for kubecf.

Relevant kubecf issue: https://github.com/cloudfoundry-incubator/kubecf/issues/744

This image was skipped: https://github.com/cloudfoundry-incubator/eirini/blob/master/docker/registry/certs/smuggler/Dockerfile

because the `FROM` line is not enough to change to another distro (there are `apk` commands in the Dockerfile) and we won't need this image in kubecf.
