### PR TITLE
Serve plaintext if `serve_plaintext` is true

### DIFF
--- a/integration/cmd/connect_test.go
+++ b/integration/cmd/connect_test.go
@@ -24,12 +24,30 @@ var _ = Describe("connect command", func() {
 		configFilePath string
 	)
 
+	getRootError := func() error {
+		_, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/", config.Properties.TLSPort))
+		return err
+	}
+
+	getRoot := func() *http.Response {
+		resp, _ := httpClient.Get(fmt.Sprintf("https://localhost:%d/", config.Properties.TLSPort))
+		return resp
+	}
+
 	BeforeEach(func() {
 		var err error
 		httpClient, err = util.MakeTestHTTPClient()
 		Expect(err).ToNot(HaveOccurred())
+
 		configFilePath = ""
 		session = nil
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		command := exec.Command(cmdPath, "connect", "-c", configFilePath) // #nosec G204
+		session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -41,49 +59,53 @@ var _ = Describe("connect command", func() {
 		}
 	})
 
-	Context("when we invoke connect command with valid config", func() {
+	Context("invoke connect command with TLS config", func() {
 		BeforeEach(func() {
 			config = util.DefaultEiriniConfig("test-ns", fixture.NextAvailablePort())
 			configFile, err := util.CreateConfigFile(config)
 			Expect(err).ToNot(HaveOccurred())
 			configFilePath = configFile.Name()
-
-			command := exec.Command(cmdPath, "connect", "-c", configFilePath) // #nosec G204
-			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(func() error {
-				_, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/", config.Properties.TLSPort))
-				return err
-			}, "10s").Should(Succeed())
-
 		})
 
-		Context("when sending a request without a client certificate", func() {
-			It("should receive a mTLS-related connection failure", func() {
-				httpClient.Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{}
-				_, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/", config.Properties.TLSPort))
-				Expect(err).To(MatchError(ContainSubstring("remote error: tls: bad certificate")))
+		It("starts serving", func() {
+			Eventually(getRootError, "10s").Should(Succeed())
+		})
 
+		Context("send a request without a client certificate", func() {
+			It("receives a mTLS-related connection failure", func() {
+				Eventually(getRootError, "10s").Should(Succeed())
+
+				httpClient.Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{}
+				Expect(getRootError()).To(MatchError(
+					ContainSubstring("remote error: tls: bad certificate")))
 			})
 		})
 
-		Context("when sending a request with an invalid client certificate", func() {
+		Context("send a request with an invalid client certificate", func() {
+
+			var clientCert tls.Certificate
+
 			BeforeEach(func() {
-				clientCert, err := tls.LoadX509KeyPair(pathToTestFixture("untrusted-cert"), pathToTestFixture("untrusted-key"))
+				var err error
+				clientCert, err = tls.LoadX509KeyPair(pathToTestFixture("untrusted-cert"), pathToTestFixture("untrusted-key"))
 				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns a mTLS-related connection failure", func() {
+				Eventually(getRootError, "10s").Should(Succeed())
 
 				httpClient.Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{clientCert}
-			})
 
-			It("we should receive a mTLS-related connection failure", func() {
-				_, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/", config.Properties.TLSPort))
-				Expect(err).To(MatchError(ContainSubstring("remote error: tls: bad certificate")))
+				Expect(getRootError()).To(MatchError(
+					ContainSubstring("remote error: tls: bad certificate")))
 			})
 		})
 
 		Context("when sending a request with a valid client certificate", func() {
 			It("should successfully connect", func() {
-				Expect(httpClient.Get(fmt.Sprintf("https://localhost:%d/", config.Properties.TLSPort))).To(PointTo(MatchFields(IgnoreExtras, Fields{
+				Eventually(getRootError, "10s").Should(Succeed())
+
+				Expect(getRoot()).To(PointTo(MatchFields(IgnoreExtras, Fields{
 					"TLS": PointTo(MatchFields(IgnoreExtras, Fields{
 						"HandshakeComplete": BeTrue(),
 					})),
@@ -92,15 +114,54 @@ var _ = Describe("connect command", func() {
 		})
 	})
 
-	Context("when we invoke connect command with invalid config", func() {
-		Context("file is missing", func() {
-			It("should fail", func() {
-				var err error
-				command := exec.Command(cmdPath, "connect", "-c", "not-found.yml") // #nosec G204
-				session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(session, "10s").Should(gexec.Exit())
-				Expect(session.ExitCode()).NotTo(BeZero())
+	Context("invoke connect command with non-existent config", func() {
+		It("fails", func() {
+			Eventually(session, "10s").Should(gexec.Exit())
+			Expect(session.ExitCode()).NotTo(BeZero())
+		})
+	})
+
+	Context("invoke connect command without TLS config", func() {
+
+		BeforeEach(func() {
+			config = util.DefaultEiriniConfig("test-ns", fixture.NextAvailablePort())
+			config.Properties.ClientCAPath = ""
+			config.Properties.ServerCertPath = ""
+			config.Properties.ServerKeyPath = ""
+
+			configFile, err := util.CreateConfigFile(config)
+			Expect(err).ToNot(HaveOccurred())
+			configFilePath = configFile.Name()
+		})
+
+		It("fails", func() {
+			Eventually(session, "10s").Should(gexec.Exit())
+			Expect(session.ExitCode()).NotTo(BeZero())
+
+		})
+
+		Context("eirini is configured to serve plaintext", func() {
+			BeforeEach(func() {
+				config = util.DefaultEiriniConfig("test-ns", fixture.NextAvailablePort())
+				config.Properties.ClientCAPath = ""
+				config.Properties.ServerCertPath = ""
+				config.Properties.ServerKeyPath = ""
+				config.Properties.ServePlaintext = true
+				config.Properties.PlaintextPort = fixture.NextAvailablePort()
+
+				configFile, err := util.CreateConfigFile(config)
+				Expect(err).ToNot(HaveOccurred())
+				configFilePath = configFile.Name()
+
+			})
+
+			It("starts a plaintext http connection", func() {
+				plaintextClient := &http.Client{}
+
+				Eventually(func() error {
+					_, err := plaintextClient.Get(fmt.Sprintf("http://localhost:%d/", config.Properties.PlaintextPort))
+					return err
+				}, "10s").Should(Succeed())
 			})
 		})
 	})

--- a/models.go
+++ b/models.go
@@ -66,6 +66,7 @@ type Properties struct {
 	ServerCertPath string `yaml:"server_cert_path"`
 	ServerKeyPath  string `yaml:"server_key_path"`
 	TLSPort        int    `yaml:"tls_port"`
+	PlaintextPort  int    `yaml:"plaintext_port"`
 
 	CCUploaderSecretName string `yaml:"cc_uploader_secret_name"`
 	CCUploaderCertPath   string `yaml:"cc_uploader_cert_path"`
@@ -98,6 +99,8 @@ type Properties struct {
 	ApplicationServiceAccount string `yaml:"application_service_account"`
 
 	AllowRunImageAsRoot bool `yaml:"allow_run_image_as_root"`
+
+	ServePlaintext bool `yaml:"serve_plaintext"`
 }
 
 type EventReporterConfig struct {


### PR DESCRIPTION
Adds a property `serve_plaintext` which is false by default. If it's explicitly set to `true` OPI will serve plaintext instead of TLS. It also adds a `plaintext_port` property to set the plaintext port.

fixes #95