### PR TITLE
Fix custom key spelling for LoggregatorCertPath

### DIFF
--- a/models.go
+++ b/models.go
@@ -128,7 +128,7 @@ type RouteEmitterConfig struct {
 
 type MetricsCollectorConfig struct {
 	LoggregatorAddress  string `yaml:"loggregator_address"`
-	LoggregatorCertPath string `yaml:"loggergator_cert_path"`
+	LoggregatorCertPath string `yaml:"loggregator_cert_path"`
 	LoggregatorKeyPath  string `yaml:"loggregator_key_path"`
 	LoggregatorCAPath   string `yaml:"loggregator_ca_path"`
 


### PR DESCRIPTION
Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `master` branch.
Forked on master.

1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.
Unfortunately, it looks like a typo made it into the custom key for yaml unmarshalling for `MetricsCollectorConfig`. The key is inconsistent with other loggregator keys.

1. Please provide automated tests (preferred) or instructions for manually testing your change.
Test coverage does not currently extend to unmarshalling out of json; test fixtures provide data directly. I can add test coverage if it is desired.