### PR TITLE
Make instance index env injector image configurable through build args

### DIFF
--- a/docker/instance-index-env-injector/Dockerfile
+++ b/docker/instance-index-env-injector/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=cloudfoundry/run:tiny
+
 FROM golang:1.15 as builder
 WORKDIR /eirini/
 COPY . .
@@ -5,7 +7,7 @@ RUN  CGO_ENABLED=0 GOOS=linux go build -mod vendor -trimpath -a -installsuffix c
 ARG GIT_SHA
 RUN if [ -z "$GIT_SHA" ]; then echo "GIT_SHA not set"; exit 1; else : ; fi
 
-FROM cloudfoundry/run:tiny
+FROM ${baseimage}
 COPY --from=builder /eirini/instance-index-env-injector /usr/local/bin/instance-index-env-injector
 USER 1001
 ENTRYPOINT [ "/usr/local/bin/instance-index-env-injector", \


### PR DESCRIPTION
To allow people to build it on a different base image

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

