### PR TITLE
stop hardcoding VCAP UID when desiring tasks and LRPs

### DIFF
--- a/k8s/desiretask.go
+++ b/k8s/desiretask.go
@@ -414,7 +414,6 @@ func (d *TaskDesirer) toJob(task *opi.Task) *batch.Job {
 					RestartPolicy: corev1.RestartPolicyNever,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &runAsNonRoot,
-						RunAsUser:    int64ptr(VcapUID),
 					},
 				},
 			},

--- a/k8s/desiretask_test.go
+++ b/k8s/desiretask_test.go
@@ -43,7 +43,6 @@ var _ = Describe("TaskDesirer", func() {
 		Expect(job.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
 		Expect(job.Spec.Template.Spec.AutomountServiceAccountToken).To(Equal(&automountServiceAccountToken))
 		Expect(job.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(PointTo(Equal(true)))
-		Expect(job.Spec.Template.Spec.SecurityContext.RunAsUser).To(PointTo(Equal(int64(2000))))
 	}
 
 	assertContainer := func(container corev1.Container, name string) {

--- a/k8s/helpers.go
+++ b/k8s/helpers.go
@@ -22,12 +22,6 @@ func int32ptr(i int) *int32 {
 	return &u
 }
 
-func int64ptr(i int) *int64 {
-	u := int64(i)
-
-	return &u
-}
-
 func IsStopped(events []v1.Event) bool {
 	if len(events) == 0 {
 		return false

--- a/k8s/statefulset.go
+++ b/k8s/statefulset.go
@@ -61,7 +61,6 @@ const (
 
 	OPIContainerName = "opi"
 
-	VcapUID                  = 2000
 	PdbMinAvailableInstances = 1
 	PodAffinityTermWeight    = 100
 )
@@ -728,7 +727,6 @@ func (m *StatefulSetDesirer) getGetSecurityContext(lrp *opi.LRP) *corev1.PodSecu
 
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot: &runAsNonRoot,
-		RunAsUser:    int64ptr(VcapUID),
 	}
 }
 

--- a/k8s/statefulset_test.go
+++ b/k8s/statefulset_test.go
@@ -262,11 +262,6 @@ var _ = Describe("Statefulset Desirer", func() {
 			Expect(statefulSet.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(PointTo(Equal(true)))
 		})
 
-		It("should run it as vcap user with numerical ID 2000", func() {
-			_, statefulSet := statefulSetClient.CreateArgsForCall(0)
-			Expect(statefulSet.Spec.Template.Spec.SecurityContext.RunAsUser).To(PointTo(Equal(int64(2000))))
-		})
-
 		It("should not create a pod disruption budget", func() {
 			Expect(pdbClient.CreateCallCount()).To(BeZero())
 		})

--- a/tests/assets/docker/Makefile
+++ b/tests/assets/docker/Makefile
@@ -1,4 +1,4 @@
-PUBLIC_IMAGES = custom-port icarus dorini
+PUBLIC_IMAGES = custom-port icarus dorini busybox
 PRIVATE_IMAGES = notdora
 ALL_IMAGES = $(PUBLIC_IMAGES) $(PRIVATE_IMAGES)
 

--- a/tests/assets/docker/busybox/Dockerfile
+++ b/tests/assets/docker/busybox/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+
+USER 2000

--- a/tests/assets/docker/icarus/Dockerfile
+++ b/tests/assets/docker/icarus/Dockerfile
@@ -1,3 +1,4 @@
 FROM busybox
 
+USER 2000
 ENTRYPOINT ["/bin/sh", "-c", "exit 1"]

--- a/tests/eats/events_crd_test.go
+++ b/tests/eats/events_crd_test.go
@@ -40,7 +40,7 @@ var _ = Describe("PodCrashEvents", func() {
 				Spec: eiriniv1.LRPSpec{
 					GUID:      lrpGUID,
 					Version:   lrpVersion,
-					Image:     "busybox",
+					Image:     "eirini/busybox",
 					AppGUID:   "the-app-guid",
 					AppName:   "k-2so",
 					SpaceName: "s",
@@ -69,7 +69,8 @@ var _ = Describe("PodCrashEvents", func() {
 				LRPs(fixture.Namespace).
 				DeleteCollection(context.Background(),
 					metav1.DeleteOptions{
-						PropagationPolicy: &backgroundPropagation},
+						PropagationPolicy: &backgroundPropagation,
+					},
 					metav1.ListOptions{
 						FieldSelector: "metadata.name=" + lrpName,
 					},

--- a/tests/eats/task_reporter_test.go
+++ b/tests/eats/task_reporter_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Tasks Reporter", func() {
 			CompletionCallback: fmt.Sprintf("%s/%s", fixture.Wiremock.URL, taskGUID),
 			Lifecycle: cf.Lifecycle{
 				DockerLifecycle: &cf.DockerLifecycle{
-					Image: "busybox",
+					Image: "eirini/busybox",
 					Command: []string{
 						"bin/sleep",
 						"10",
@@ -100,7 +100,6 @@ var _ = Describe("Tasks Reporter", func() {
 			Eventually(fixture.Wiremock.GetCountFn(requestMatcher), "1m").Should(BeNumerically(">", 1))
 			Eventually(jobExists(taskGUID)).Should(BeFalse())
 		})
-
 	})
 })
 

--- a/tests/eats/tasks_crd_test.go
+++ b/tests/eats/tasks_crd_test.go
@@ -84,9 +84,9 @@ var _ = Describe("Tasks CRD", func() {
 				Env: map[string]string{
 					"FOO": "BAR",
 				},
-				Image: "ubuntu",
+				Image: "eirini/busybox",
 				Command: []string{
-					"bin/bash",
+					"sh",
 					"-c",
 					"sleep 1",
 				},
@@ -104,7 +104,6 @@ var _ = Describe("Tasks CRD", func() {
 				metav1.ListOptions{FieldSelector: "metadata.name=" + taskName},
 			)
 		Expect(err).NotTo(HaveOccurred())
-
 	})
 
 	Describe("Creating a Task CRD", func() {
@@ -132,9 +131,9 @@ var _ = Describe("Tasks CRD", func() {
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 			taskContainer := job.Spec.Template.Spec.Containers[0]
-			Expect(taskContainer.Image).To(Equal("ubuntu"))
+			Expect(taskContainer.Image).To(Equal("eirini/busybox"))
 			Expect(taskContainer.Env).To(ContainElement(corev1.EnvVar{Name: "FOO", Value: "BAR"}))
-			Expect(taskContainer.Command).To(Equal([]string{"bin/bash", "-c", "sleep 1"}))
+			Expect(taskContainer.Command).To(Equal([]string{"sh", "-c", "sleep 1"}))
 
 			Eventually(getJobConditions).Should(ConsistOf(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(batchv1.JobComplete),

--- a/tests/eats/tasks_test.go
+++ b/tests/eats/tasks_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Tasks", func() {
 			CompletionCallback: completionCallback,
 			Lifecycle: cf.Lifecycle{
 				DockerLifecycle: &cf.DockerLifecycle{
-					Image: "busybox",
+					Image: "eirini/busybox",
 					Command: []string{
 						"/bin/sleep",
 						"0.2",

--- a/tests/integration/clients_test.go
+++ b/tests/integration/clients_test.go
@@ -446,7 +446,7 @@ var _ = Describe("Jobs", func() {
 							Containers: []corev1.Container{
 								{
 									Name:            "test",
-									Image:           "busybox",
+									Image:           "eirini/busybox",
 									ImagePullPolicy: corev1.PullAlways,
 									Command:         []string{"echo", "hi"},
 								},

--- a/tests/integration/events/events_test.go
+++ b/tests/integration/events/events_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Events", func() {
 			lrp = opi.LRP{
 				Command:         lrpCommand,
 				TargetInstances: 1,
-				Image:           "busybox",
+				Image:           "eirini/busybox",
 				LRPIdentifier:   opi.LRPIdentifier{GUID: tests.GenerateGUID(), Version: tests.GenerateGUID()},
 			}
 			Expect(lrpDesirer.Desire(fixture.Namespace, &lrp)).To(Succeed())
@@ -191,7 +191,7 @@ var _ = Describe("Events", func() {
 		JustBeforeEach(func() {
 			task := opi.Task{
 				Command: []string{"exit", "1"},
-				Image:   "busybox",
+				Image:   "eirini/busybox",
 				GUID:    tests.GenerateGUID(),
 			}
 			Expect(taskDesirer.Desire(fixture.Namespace, &task)).To(Succeed())
@@ -212,7 +212,7 @@ var _ = Describe("Events", func() {
 					Containers: []v1.Container{
 						{
 							Name:    "potato",
-							Image:   "busybox",
+							Image:   "eirini/busybox",
 							Command: []string{"exit", "1"},
 						},
 					},

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -159,7 +159,7 @@ func createPod(ns, name string, labels map[string]string) {
 			Containers: []corev1.Container{
 				{
 					Name:  "busybox",
-					Image: "busybox",
+					Image: "eirini/busybox",
 				},
 			},
 		},
@@ -219,7 +219,7 @@ func createLRP(name string) *opi.LRP {
 		AppName:         name,
 		SpaceName:       "space-foo",
 		TargetInstances: 2,
-		Image:           "busybox",
+		Image:           "eirini/busybox",
 		AppURIs:         []opi.Route{{Hostname: "foo.example.com", Port: 8080}},
 		LRPIdentifier:   opi.LRPIdentifier{GUID: tests.GenerateGUID(), Version: tests.GenerateGUID()},
 		LRP:             "metadata",
@@ -336,7 +336,7 @@ func createJob(ns, name string, labels map[string]string) *batchv1.Job {
 					Containers: []corev1.Container{
 						{
 							Name:            "test",
-							Image:           "busybox",
+							Image:           "eirini/busybox",
 							ImagePullPolicy: corev1.PullAlways,
 							Command:         []string{"echo", "hi"},
 						},

--- a/tests/integration/opi/desire_app_test.go
+++ b/tests/integration/opi/desire_app_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Desire App", func() {
 			"disk_mb": 512,
 			"lifecycle": {
 				"docker_lifecycle": {
-				"image": "busybox",
+				"image": "eirini/busybox",
 				"command": ["/bin/sleep", "100"]
 				}
 			},
@@ -115,7 +115,7 @@ var _ = Describe("Desire App", func() {
 					"disk_mb": 512,
 					"lifecycle": {
 						"docker_lifecycle": {
-						"image": "busybox",
+						"image": "eirini/busybox",
 						"command": ["/bin/sleep", "100"]
 						}
 					},
@@ -147,7 +147,7 @@ var _ = Describe("Desire App", func() {
 					"disk_mb": 512,
 					"lifecycle": {
 						"docker_lifecycle": {
-						"image": "busybox",
+						"image": "eirini/busybox",
 						"command": ["/bin/sleep", "100"]
 						}
 					},

--- a/tests/integration/opi/list_app_test.go
+++ b/tests/integration/opi/list_app_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 var _ = Describe("ListAppTest", func() {
-
-	var (
-		configuredNamespaceAppGUID string
-	)
+	var configuredNamespaceAppGUID string
 
 	BeforeEach(func() {
 		configuredNamespaceAppGUID = tests.GenerateGUID()
@@ -32,7 +29,6 @@ var _ = Describe("ListAppTest", func() {
 		Expect(apps).To(HaveLen(1))
 		Expect(apps[0].GUID).To(Equal(configuredNamespaceAppGUID))
 	})
-
 })
 
 func desireLRPWithGUID(guid, namespace string) {
@@ -44,7 +40,7 @@ func desireLRPWithGUID(guid, namespace string) {
 		DiskMB:    512,
 		Lifecycle: cf.Lifecycle{
 			DockerLifecycle: &cf.DockerLifecycle{
-				Image:   "busybox",
+				Image:   "eirini/busybox",
 				Command: []string{"/bin/sleep", "100"},
 			},
 		},

--- a/tests/integration/opi/task_completion_test.go
+++ b/tests/integration/opi/task_completion_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Tasks completion", func() {
 			Namespace: fixture.Namespace,
 			Lifecycle: cf.Lifecycle{
 				DockerLifecycle: &cf.DockerLifecycle{
-					Image:   "busybox",
+					Image:   "eirini/busybox",
 					Command: []string{"/bin/sleep", "1"},
 				},
 			},

--- a/tests/integration/opi/task_test.go
+++ b/tests/integration/opi/task_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Tasks", func() {
 					Environment: []cf.EnvironmentVariable{{Name: "my-env", Value: "my-value"}},
 					Lifecycle: cf.Lifecycle{
 						DockerLifecycle: &cf.DockerLifecycle{
-							Image:   "busybox",
+							Image:   "eirini/busybox",
 							Command: []string{"/bin/echo", "hello"},
 						},
 					},
@@ -156,7 +156,7 @@ var _ = Describe("Tasks", func() {
 					jobContainers := jobs.Items[0].Spec.Template.Spec.Containers
 					Expect(jobContainers).To(HaveLen(1))
 					Expect(jobContainers[0].Env).To(ContainElement(corev1.EnvVar{Name: "my-env", Value: "my-value"}))
-					Expect(jobContainers[0].Image).To(Equal("busybox"))
+					Expect(jobContainers[0].Image).To(Equal("eirini/busybox"))
 					Expect(jobContainers[0].Command).To(ConsistOf("/bin/echo", "hello"))
 				})
 
@@ -316,7 +316,7 @@ var _ = Describe("Tasks", func() {
 					Namespace: "",
 					Lifecycle: cf.Lifecycle{
 						DockerLifecycle: &cf.DockerLifecycle{
-							Image:   "busybox",
+							Image:   "eirini/busybox",
 							Command: []string{"/bin/echo", "hello"},
 						},
 					},
@@ -345,7 +345,7 @@ var _ = Describe("Tasks", func() {
 					Namespace: fixture.CreateExtraNamespace(),
 					Lifecycle: cf.Lifecycle{
 						DockerLifecycle: &cf.DockerLifecycle{
-							Image:   "busybox",
+							Image:   "eirini/busybox",
 							Command: []string{"/bin/echo", "hello"},
 						},
 					},
@@ -397,7 +397,7 @@ var _ = Describe("Tasks", func() {
 				Namespace: fixture.Namespace,
 				Lifecycle: cf.Lifecycle{
 					DockerLifecycle: &cf.DockerLifecycle{
-						Image:   "busybox",
+						Image:   "eirini/busybox",
 						Command: []string{"/bin/sleep", "100"},
 					},
 				},
@@ -502,7 +502,7 @@ var _ = Describe("Tasks", func() {
 				Namespace: fixture.Namespace,
 				Lifecycle: cf.Lifecycle{
 					DockerLifecycle: &cf.DockerLifecycle{
-						Image:   "busybox",
+						Image:   "eirini/busybox",
 						Command: []string{"/bin/sleep", "100"},
 					},
 				},

--- a/tests/integration/task-reporter/task_reporter_test.go
+++ b/tests/integration/task-reporter/task_reporter_test.go
@@ -77,7 +77,7 @@ var _ = Describe("TaskReporter", func() {
 
 		taskGUID := tests.GenerateGUID()
 		task = &opi.Task{
-			Image:              "busybox",
+			Image:              "eirini/busybox",
 			Command:            []string{"echo", "hi"},
 			GUID:               taskGUID,
 			CompletionCallback: fmt.Sprintf("%s/the-callback", cloudControllerServer.URL()),


### PR DESCRIPTION
see https://github.com/cloudfoundry/cf-for-k8s/issues/483#issue-711800977 for context about what all was broken by having a hardcoded UID. In short, containers that were built to run with non-2000 UIDs will not run. runAsNonRoot should prevent users from running as UID 0, giving them root on the host.
