### PR TITLE
Inspect image user

### DIFF
--- a/bifrost/convert.go
+++ b/bifrost/convert.go
@@ -19,6 +19,7 @@ var dockerRX = regexp.MustCompile(`([a-zA-Z0-9.-]+)(:([0-9]+))?/(\S+/\S+)`) //no
 
 type lifecycleOptions struct {
 	command         []string
+	user            string
 	env             map[string]string
 	image           string
 	privateRegistry *opi.PrivateRegistry
@@ -98,6 +99,7 @@ func (c *OPIConverter) ConvertLRP(request cf.DesireLRPRequest) (opi.LRP, error) 
 		Env:                    mergeMaps(request.Environment, env, lrpLifecycleOptions.env),
 		Health:                 healthcheck,
 		Ports:                  request.Ports,
+		User:                   lrpLifecycleOptions.user,
 		MemoryMB:               request.MemoryMB,
 		DiskMB:                 request.DiskMB,
 		CPUWeight:              request.CPUWeight,
@@ -253,6 +255,7 @@ func (c *OPIConverter) getLifecycleOptions(request cf.DesireLRPRequest) (*lifecy
 	lifecycle := request.Lifecycle.DockerLifecycle
 	options.image = lifecycle.Image
 	options.command = lifecycle.Command
+	options.user = lifecycle.User
 	options.runsAsRoot, err = c.isAllowedToRunAsRoot(lifecycle)
 
 	if err != nil {

--- a/bifrost/docker_staging.go
+++ b/bifrost/docker_staging.go
@@ -59,14 +59,10 @@ type port struct {
 	Protocol string `json:"Protocol"`
 }
 
-type user struct {
-	User string
-}
-
 type executionMetadata struct {
 	Cmd   []string `json:"cmd"`
 	Ports []port   `json:"ports"`
-	User  user     `json:"user"`
+	User  string     `json:"user"`
 }
 
 func (s DockerStaging) TransferStaging(ctx context.Context, stagingGUID string, request cf.StagingRequest) error {
@@ -92,7 +88,7 @@ func (s DockerStaging) TransferStaging(ctx context.Context, stagingGUID string, 
 	}
 	userFromConfig, err := parseUser(imageConfig)
 
-	stagingResult, err := buildStagingResult(request.Lifecycle.DockerLifecycle.Image, ports, user{User: userFromConfig})
+	stagingResult, err := buildStagingResult(request.Lifecycle.DockerLifecycle.Image, ports, userFromConfig)
 	if err != nil {
 		logger.Error("failed-to-build-staging-result", err)
 
@@ -165,8 +161,8 @@ func parseUser(imageConfig *v1.ImageConfig) (string, error) {
 	return "", errors.New("Image has no USER instruction")
 }
 
-func buildStagingResult(image string, ports []port, user user) (string, error) {
-	executionMetadataJSON, err := json.Marshal(executionMetadata{
+func buildStagingResult(image string, ports []port, user string) (string, error) {
+	executionMetadataJSON, err := json.Marshal(	executionMetadata{
 		Cmd:   []string{},
 		Ports: ports,
 		User:  user,

--- a/bifrost/docker_staging_test.go
+++ b/bifrost/docker_staging_test.go
@@ -45,6 +45,7 @@ var _ = Describe("DockerStager", func() {
 				ExposedPorts: map[string]struct{}{
 					"8888/tcp": {},
 				},
+				User: "foobrizzle",
 			}, nil)
 
 			parser.Returns("//some-valid-docker-ref", nil)
@@ -91,7 +92,7 @@ var _ = Describe("DockerStager", func() {
 			Expect(payload.LifecycleType).To(Equal("docker"))
 			Expect(payload.LifecycleMetadata.DockerImage).To(Equal("eirini/some-app:some-tag"))
 			Expect(payload.ProcessTypes.Web).To(BeEmpty())
-			Expect(payload.ExecutionMetadata).To(Equal(`{"cmd":[],"ports":[{"Port":8888,"Protocol":"tcp"}]}`))
+			Expect(payload.ExecutionMetadata).To(Equal(`{"cmd":[],"ports":[{"Port":8888,"Protocol":"tcp"}],"user":{"User":"foobrizzle"}}`))
 		})
 
 		Context("when the image is from a private registry", func() {

--- a/bifrost/docker_staging_test.go
+++ b/bifrost/docker_staging_test.go
@@ -92,7 +92,7 @@ var _ = Describe("DockerStager", func() {
 			Expect(payload.LifecycleType).To(Equal("docker"))
 			Expect(payload.LifecycleMetadata.DockerImage).To(Equal("eirini/some-app:some-tag"))
 			Expect(payload.ProcessTypes.Web).To(BeEmpty())
-			Expect(payload.ExecutionMetadata).To(Equal(`{"cmd":[],"ports":[{"Port":8888,"Protocol":"tcp"}],"user":{"User":"foobrizzle"}}`))
+			Expect(payload.ExecutionMetadata).To(Equal(`{"cmd":[],"ports":[{"Port":8888,"Protocol":"tcp"}],"user":"foobrizzle"}`))
 		})
 
 		Context("when the image is from a private registry", func() {

--- a/k8s/statefulset.go
+++ b/k8s/statefulset.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"code.cloudfoundry.org/eirini"
@@ -731,8 +732,15 @@ func (m *StatefulSetDesirer) getGetSecurityContext(lrp *opi.LRP) *corev1.PodSecu
 
 	runAsNonRoot := true
 
+	uid, err := m.parseUser(lrp)
+	if err != nil {
+		uid = 1000
+	}
+	var uidInt = int64(uid)
+
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot: &runAsNonRoot,
+		RunAsUser:    &uidInt,
 	}
 }
 
@@ -802,4 +810,8 @@ func applyOpts(statefulset *appsv1.StatefulSet, opts ...DesireOption) error {
 	}
 
 	return nil
+}
+
+func (m *StatefulSetDesirer) parseUser(lrp *opi.LRP) (int, error) {
+	return strconv.Atoi(lrp.User)
 }

--- a/models/cf/models.go
+++ b/models/cf/models.go
@@ -79,6 +79,7 @@ type Lifecycle struct {
 type DockerLifecycle struct {
 	Image            string   `json:"image"`
 	Command          []string `json:"command"`
+	User             string   `json:"user"`
 	RegistryUsername string   `json:"registry_username"`
 	RegistryPassword string   `json:"registry_password"`
 }
@@ -139,6 +140,7 @@ type StagingLifecycle struct {
 
 type StagingDockerLifecycle struct {
 	Image            string `json:"image"`
+	User             string `json:"user"`
 	RegistryUsername string `json:"registry_username"`
 	RegistryPassword string `json:"registry_password"`
 }

--- a/opi/model.go
+++ b/opi/model.go
@@ -39,6 +39,7 @@ type LRP struct {
 	Env                    map[string]string
 	Health                 Healtcheck
 	Ports                  []int32
+	User				   string
 	TargetInstances        int
 	RunningInstances       int
 	MemoryMB               int64

--- a/pkg/apis/eirini/v1/lrp.go
+++ b/pkg/apis/eirini/v1/lrp.go
@@ -33,6 +33,7 @@ type LRPSpec struct {
 	Env                    map[string]string `json:"env,omitempty"`
 	Health                 Healtcheck        `json:"health"`
 	Ports                  []int32           `json:"ports,omitempty"`
+	User                   string            `json:"user,omitempty"`
 	Instances              int               `json:"instances"`
 	MemoryMB               int64             `json:"memoryMB"`
 	DiskMB                 int64             `json:"diskMB"`

--- a/tests/integration/opi/docker_staging_test.go
+++ b/tests/integration/opi/docker_staging_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Docker Staging", func() {
 				Expect(request.Error).To(BeNil())
 				stagingResult := bifrost.StagingResult{}
 				Expect(json.Unmarshal(*request.Result, &stagingResult)).To(Succeed())
-				Expect(stagingResult.ExecutionMetadata).To(Equal(`{"cmd":[],"ports":[{"Port":8888,"Protocol":"tcp"}]}`))
+				Expect(stagingResult.ExecutionMetadata).To(Equal(`{"cmd":[],"ports":[{"Port":8888,"Protocol":"tcp"}],"user":{"User":"1001"}}`))
 				Expect(stagingResult.LifecycleType).To(Equal("docker"))
 				Expect(stagingResult.LifecycleMetadata.DockerImage).To(Equal("eirini/custom-port"))
 				Expect(stagingResult.ProcessTypes).To(Equal(bifrost.ProcessTypes{Web: ""}))


### PR DESCRIPTION
Preliminary PR as per discussion with Giuseppe Capizzi - https://cloudfoundry.slack.com/archives/C8RU3BZ26/p1605550105243100?thread_ts=1605540085.240900&cid=C8RU3BZ26

The functionality here is to extract the user from the image and pass it the CC on `docker_staging`. On the desire side, it is included with the payload and used for the `PodSecurityContext` as the `RunAsUser`.

Due to `RunAsNonRoot`, the `RunAsUser` requires a numeric UID. In this implementation, there is a naive check to see if the user is parseable, then assigns a default UID if is not. I'm unsure if this functionality belongs in `StatefulSet` generation or whether CC should do this conversion. One one hand, the numeric UID requirement is a result of Kubernetes, so it isn't really a CC concern. On the other hand, CC is the hub of operations, so it should maybe understand the requirements of desires to Eirini.